### PR TITLE
Add support for --ignore-reqs

### DIFF
--- a/pip_check_reqs/common.py
+++ b/pip_check_reqs/common.py
@@ -5,6 +5,10 @@ import logging
 import os
 import re
 
+from pip.download import PipSession
+from pip.req import parse_requirements
+from pip.utils import normalize_name
+
 log = logging.getLogger(__name__)
 
 
@@ -115,6 +119,18 @@ def find_imported_modules(options):
             vis.set_location(filename)
             vis.visit(ast.parse(content))
     return vis.finalise()
+
+
+def find_required_modules(options):
+    explicit = set()
+    for requirement in parse_requirements('requirements.txt',
+            session=PipSession()):
+        if options.ignore_reqs(requirement):
+            log.debug('ignoring requirement: %s', requirement.name)
+        else:
+            log.debug('found requirement: %s', requirement.name)
+            explicit.add(normalize_name(requirement.name))
+    return explicit
 
 
 def is_package_file(path):

--- a/pip_check_reqs/find_extra_reqs.py
+++ b/pip_check_reqs/find_extra_reqs.py
@@ -5,8 +5,6 @@ import os
 import sys
 
 from pip.commands.show import search_packages_info
-from pip.download import PipSession
-from pip.req import parse_requirements
 from pip.utils import get_installed_distributions, normalize_name
 
 from pip_check_reqs import common
@@ -50,11 +48,7 @@ def find_extra_reqs(options):
                 modname, info.filename)
 
     # 4. compare with requirements.txt
-    explicit = set()
-    for requirement in parse_requirements('requirements.txt',
-            session=PipSession()):
-        log.debug('found requirement: %s', requirement.name)
-        explicit.add(normalize_name(requirement.name))
+    explicit = common.find_required_modules(options)
 
     return [name for name in explicit if name not in used]
 
@@ -70,6 +64,9 @@ def main():
     parser.add_option("-m", "--ignore-module", dest="ignore_mods",
         action="append", default=[],
         help="used module names (globs are ok) to ignore")
+    parser.add_option("-r", "--ignore-requirement", dest="ignore_reqs",
+        action="append", default=[],
+        help="reqs in requirements.txt to ignore")
     parser.add_option("-v", "--verbose", dest="verbose",
         action="store_true", default=False, help="be more verbose")
     parser.add_option("-d", "--debug", dest="debug",
@@ -88,6 +85,7 @@ def main():
 
     options.ignore_files = common.ignorer(options.ignore_files)
     options.ignore_mods = common.ignorer(options.ignore_mods)
+    options.ignore_reqs = common.ignorer(options.ignore_reqs)
 
     options.paths = args
 

--- a/tests/test_find_extra_reqs.py
+++ b/tests/test_find_extra_reqs.py
@@ -21,6 +21,7 @@ def fake_opts():
             version = False
             ignore_files = []
             ignore_mods = []
+            ignore_reqs = []
         options = options()
         args = ['ham.py']
 
@@ -64,10 +65,14 @@ def test_find_extra_reqs(monkeypatch):
 
     FakeReq = collections.namedtuple('FakeReq', ['name'])
     requirements = [FakeReq('foobar')]
-    monkeypatch.setattr(find_extra_reqs, 'parse_requirements',
+    monkeypatch.setattr(common, 'parse_requirements',
         pretend.call_recorder(lambda a, session=None: requirements))
 
-    result = find_extra_reqs.find_extra_reqs(None)
+    class options:
+        ignore_reqs = lambda x, y: False
+    options = options()
+
+    result = find_extra_reqs.find_extra_reqs(options)
     assert result == ['foobar']
 
 
@@ -117,6 +122,7 @@ def test_logging_config(monkeypatch, caplog, verbose_cfg, debug_cfg, result):
         version = False
         ignore_files = []
         ignore_mods = []
+        ignore_reqs = []
     options = options()
 
     class FakeOptParse:


### PR DESCRIPTION
When checking for extra requirements sometimes we may want to
ignore various ones such as setuptools or pbr etc.
