### PR TITLE
Another fix for pip's loss of "normalize_name"

### DIFF
--- a/pip_check_reqs/common.py
+++ b/pip_check_reqs/common.py
@@ -5,9 +5,9 @@ import logging
 import os
 import re
 
+from packaging.utils import canonicalize_name
 from pip.download import PipSession
 from pip.req import parse_requirements
-from pip.utils import normalize_name
 
 log = logging.getLogger(__name__)
 
@@ -129,7 +129,7 @@ def find_required_modules(options):
             log.debug('ignoring requirement: %s', requirement.name)
         else:
             log.debug('found requirement: %s', requirement.name)
-            explicit.add(normalize_name(requirement.name))
+            explicit.add(canonicalize_name(requirement.name))
     return explicit
 
 

--- a/pip_check_reqs/find_extra_reqs.py
+++ b/pip_check_reqs/find_extra_reqs.py
@@ -24,7 +24,7 @@ def find_extra_reqs(options):
     for package in search_packages_info(all_pkgs):
         log.debug('installed package: %s (at %s)', package['name'],
             package['location'])
-        for f in package['files'] or []:
+        for f in package.get('files', []) or []:
             path = os.path.realpath(os.path.join(package['location'], f))
             installed_files[path] = package['name']
             package_path = common.is_package_file(path)

--- a/pip_check_reqs/find_extra_reqs.py
+++ b/pip_check_reqs/find_extra_reqs.py
@@ -4,8 +4,9 @@ import optparse
 import os
 import sys
 
+from packaging.utils import canonicalize_name
 from pip.commands.show import search_packages_info
-from pip.utils import get_installed_distributions, normalize_name
+from pip.utils import get_installed_distributions
 
 from pip_check_reqs import common
 
@@ -38,7 +39,7 @@ def find_extra_reqs(options):
     for modname, info in used_modules.items():
         # probably standard library if it's not in the files list
         if info.filename in installed_files:
-            used_name = normalize_name(installed_files[info.filename])
+            used_name = canonicalize_name(installed_files[info.filename])
             log.debug('used module: %s (from package %s)', modname,
                 installed_files[info.filename])
             used[used_name].append(info)

--- a/pip_check_reqs/find_missing_reqs.py
+++ b/pip_check_reqs/find_missing_reqs.py
@@ -4,10 +4,11 @@ import optparse
 import os
 import sys
 
+from packaging.utils import canonicalize_name
 from pip.commands.show import search_packages_info
 from pip.download import PipSession
 from pip.req import parse_requirements
-from pip.utils import get_installed_distributions, normalize_name
+from pip.utils import get_installed_distributions
 
 from pip_check_reqs import common
 
@@ -40,7 +41,7 @@ def find_missing_reqs(options):
     for modname, info in used_modules.items():
         # probably standard library if it's not in the files list
         if info.filename in installed_files:
-            used_name = normalize_name(installed_files[info.filename])
+            used_name = canonicalize_name(installed_files[info.filename])
             log.debug('used module: %s (from package %s)', modname,
                 installed_files[info.filename])
             used[used_name].append(info)
@@ -54,7 +55,7 @@ def find_missing_reqs(options):
     for requirement in parse_requirements('requirements.txt',
             session=PipSession()):
         log.debug('found requirement: %s', requirement.name)
-        explicit.add(normalize_name(requirement.name))
+        explicit.add(canonicalize_name(requirement.name))
 
     return [(name, used[name]) for name in used
         if name not in explicit]

--- a/pip_check_reqs/find_missing_reqs.py
+++ b/pip_check_reqs/find_missing_reqs.py
@@ -26,7 +26,7 @@ def find_missing_reqs(options):
     for package in search_packages_info(all_pkgs):
         log.debug('installed package: %s (at %s)', package['name'],
             package['location'])
-        for file in package['files'] or []:
+        for file in package.get('files', []) or []:
             path = os.path.realpath(os.path.join(package['location'], file))
             installed_files[path] = package['name']
             package_path = common.is_package_file(path)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 pip>=6.0
+packaging

--- a/setup.py
+++ b/setup.py
@@ -38,4 +38,8 @@ setup(
             'pip-extra-reqs=pip_check_reqs.find_extra_reqs:main',
         ],
     },
+    install_requires=[
+        'packaging',
+        'pip',
+    ],
 )


### PR DESCRIPTION
As @jaypipes suggested in PR #8, I have replaced `normalize_name` with `canonicalize_name` from the "packaging" distribution.

I also fixed an issue with the `packaging` dict lacking the "files" key. Ordinarily I would make multiple branches and PRs but this seems too trivial and my time is short.
