### PR TITLE
Run tests nightly with the latest pip version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    # Run at 1:00 every day
+    - cron:  '0 1 * * *'
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,9 @@ jobs:
     strategy:
       matrix:
         # These versions match the minimum and maximum versions of pip in
-        # requirements.txt
-        pip-version: ['==10.0.1', '<= 19']
+        # requirements.txt.
+        # An empty string here represents the latest version.
+        pip-version: ['==10.0.1', '']
         python-version: [3.6, 3.7, 3.8]
 
     steps:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,8 @@ Release History
 - Remove support for Python 2.
   Please use an older version of this tool if you require that support.
 - Remove requirement for setuptools.
-- Add restriction on the pip version to install to match the pip versions which work.
+- Support newer versions of pip, including the current version, for more features (20.1.1).
+  Thanks to @Czaki for important parts of this change.
 
 2.0.1
 

--- a/pip_check_reqs/common.py
+++ b/pip_check_reqs/common.py
@@ -125,15 +125,26 @@ def find_imported_modules(options):
     return vis.finalise()
 
 
-def find_required_modules(options):
+def find_required_modules(options, requirements_filename: str):
     explicit = set()
-    for requirement in parse_requirements('requirements.txt',
+    for requirement in parse_requirements(requirements_filename,
                                           session=PipSession()):
+        try:
+            requirement_name = requirement.name
+        # The type of "requirement" changed between pip versions.
+        # We exclude the "except" from coverage so that on any pip version we
+        # can report 100% coverage.
+        except AttributeError:  # pragma: no cover
+            from pip._internal.req.constructors import install_req_from_line
+            requirement_name = install_req_from_line(
+                requirement.requirement,
+            ).name
+
         if options.ignore_reqs(requirement):
-            log.debug('ignoring requirement: %s', requirement.name)
+            log.debug('ignoring requirement: %s', requirement_name)
         else:
-            log.debug('found requirement: %s', requirement.name)
-            explicit.add(canonicalize_name(requirement.name))
+            log.debug('found requirement: %s', requirement_name)
+            explicit.add(canonicalize_name(requirement_name))
     return explicit
 
 
@@ -153,9 +164,19 @@ def ignorer(ignore_cfg):
 
     def f(candidate, ignore_cfg=ignore_cfg):
         for ignore in ignore_cfg:
-            if fnmatch.fnmatch(candidate, ignore):
+            try:
+                from pip._internal.req.constructors import (
+                    install_req_from_line,
+                )
+                candidate_path = install_req_from_line(
+                    candidate.requirement,
+                ).name
+            except (ImportError, AttributeError):
+                candidate_path = candidate
+
+            if fnmatch.fnmatch(candidate_path, ignore):
                 return True
-            elif fnmatch.fnmatch(os.path.relpath(candidate), ignore):
+            elif fnmatch.fnmatch(os.path.relpath(candidate_path), ignore):
                 return True
         return False
 

--- a/pip_check_reqs/common.py
+++ b/pip_check_reqs/common.py
@@ -168,11 +168,14 @@ def ignorer(ignore_cfg):
                 from pip._internal.req.constructors import (
                     install_req_from_line,
                 )
-                candidate_path = install_req_from_line(
+                candidate_path = install_req_from_line(  # pragma: no cover
                     candidate.requirement,
                 ).name
             except (ImportError, AttributeError):
-                candidate_path = candidate
+                try:
+                    candidate_path = candidate.name
+                except AttributeError:
+                    candidate_path = candidate
 
             if fnmatch.fnmatch(candidate_path, ignore):
                 return True

--- a/pip_check_reqs/common.py
+++ b/pip_check_reqs/common.py
@@ -6,7 +6,11 @@ import os
 import re
 
 from packaging.utils import canonicalize_name
-from pip._internal.download import PipSession
+# Between different versions of pip the location of PipSession has changed.
+try:
+     from pip._internal.network.session import PipSession
+except ImportError:  # pragma: no cover
+    from pip._internal.download import PipSession
 from pip._internal.req.req_file import parse_requirements
 
 log = logging.getLogger(__name__)

--- a/pip_check_reqs/common.py
+++ b/pip_check_reqs/common.py
@@ -8,7 +8,7 @@ import re
 from packaging.utils import canonicalize_name
 # Between different versions of pip the location of PipSession has changed.
 try:
-     from pip._internal.network.session import PipSession
+    from pip._internal.network.session import PipSession
 except ImportError:  # pragma: no cover
     from pip._internal.download import PipSession
 from pip._internal.req.req_file import parse_requirements

--- a/pip_check_reqs/find_extra_reqs.py
+++ b/pip_check_reqs/find_extra_reqs.py
@@ -12,7 +12,7 @@ from pip_check_reqs import common
 log = logging.getLogger(__name__)
 
 
-def find_extra_reqs(options):
+def find_extra_reqs(options, requirements_filename):
     # 1. find files used by imports in the code (as best we can without
     #    executing)
     used_modules = common.find_imported_modules(options)
@@ -50,7 +50,10 @@ def find_extra_reqs(options):
                 modname, info.filename)
 
     # 4. compare with requirements.txt
-    explicit = common.find_required_modules(options)
+    explicit = common.find_required_modules(
+        options=options,
+        requirements_filename=requirements_filename,
+    )
 
     return [name for name in explicit if name not in used]
 
@@ -121,12 +124,20 @@ def main():
 
     log.info('using pip_check_reqs-%s from %s', __version__, __file__)
 
-    extras = find_extra_reqs(options)
+    requirements_filename = 'requirements.txt'
+    extras = find_extra_reqs(
+        options=options,
+        requirements_filename=requirements_filename,
+    )
 
     if extras:
         log.warning('Extra requirements:')
     for name in extras:
-        log.warning('%s in requirements.txt' % name)
+        message = '{name} in {requirements_filename}'.format(
+            name=name,
+            requirements_filename=requirements_filename,
+        )
+        log.warning(message)
 
     if extras:
         sys.exit(1)

--- a/pip_check_reqs/find_missing_reqs.py
+++ b/pip_check_reqs/find_missing_reqs.py
@@ -6,7 +6,11 @@ import sys
 
 from packaging.utils import canonicalize_name
 from pip._internal.commands.show import search_packages_info
-from pip._internal.download import PipSession
+# Between different versions of pip the location of PipSession has changed.
+try:
+     from pip._internal.network.session import PipSession
+except ImportError:  # pragma: no cover
+    from pip._internal.download import PipSession
 from pip._internal.req.req_file import parse_requirements
 from pip._internal.utils.misc import get_installed_distributions
 

--- a/pip_check_reqs/find_missing_reqs.py
+++ b/pip_check_reqs/find_missing_reqs.py
@@ -68,7 +68,10 @@ def find_missing_reqs(options, requirements_filename):
         # We exclude the "except" from coverage so that on any pip version we
         # can report 100% coverage.
         except AttributeError:  # pragma: no cover
-            requirement_name = requirement.requirement
+            from pip._internal.req.constructors import install_req_from_line
+            requirement_name = install_req_from_line(
+                requirement.requirement,
+            ).name
 
         log.debug('found requirement: %s', requirement_name)
         explicit.add(canonicalize_name(requirement_name))

--- a/pip_check_reqs/find_missing_reqs.py
+++ b/pip_check_reqs/find_missing_reqs.py
@@ -8,7 +8,7 @@ from packaging.utils import canonicalize_name
 from pip._internal.commands.show import search_packages_info
 # Between different versions of pip the location of PipSession has changed.
 try:
-     from pip._internal.network.session import PipSession
+    from pip._internal.network.session import PipSession
 except ImportError:  # pragma: no cover
     from pip._internal.download import PipSession
 from pip._internal.req.req_file import parse_requirements

--- a/pip_check_reqs/find_missing_reqs.py
+++ b/pip_check_reqs/find_missing_reqs.py
@@ -19,7 +19,7 @@ from pip_check_reqs import common
 log = logging.getLogger(__name__)
 
 
-def find_missing_reqs(options):
+def find_missing_reqs(options, requirements_filename):
     # 1. find files used by imports in the code (as best we can without
     #    executing)
     used_modules = common.find_imported_modules(options)
@@ -58,10 +58,11 @@ def find_missing_reqs(options):
 
     # 4. compare with requirements.txt
     explicit = set()
-    for requirement in parse_requirements('requirements.txt',
-                                          session=PipSession()):
-        import pdb; pdb.set_trace()
-        log.debug('found requirement: %s', requirement.requirement)
+    for requirement in parse_requirements(
+        requirements_filename,
+        session=PipSession(),
+    ):
+        log.debug('found requirement: %s', requirement.name)
         explicit.add(canonicalize_name(requirement.name))
 
     return [(name, used[name]) for name in used if name not in explicit]
@@ -126,7 +127,11 @@ def main():
 
     log.info('using pip_check_reqs-%s from %s', __version__, __file__)
 
-    missing = find_missing_reqs(options)
+    requirements_filename = 'requirements.txt'
+    missing = find_missing_reqs(
+        options=options,
+        requirements_filename=requirements_filename,
+    )
 
     if missing:
         log.warning('Missing requirements:')

--- a/pip_check_reqs/find_missing_reqs.py
+++ b/pip_check_reqs/find_missing_reqs.py
@@ -60,7 +60,8 @@ def find_missing_reqs(options):
     explicit = set()
     for requirement in parse_requirements('requirements.txt',
                                           session=PipSession()):
-        log.debug('found requirement: %s', requirement.name)
+        import pdb; pdb.set_trace()
+        log.debug('found requirement: %s', requirement.requirement)
         explicit.add(canonicalize_name(requirement.name))
 
     return [(name, used[name]) for name in used if name not in explicit]

--- a/pip_check_reqs/find_missing_reqs.py
+++ b/pip_check_reqs/find_missing_reqs.py
@@ -62,8 +62,16 @@ def find_missing_reqs(options, requirements_filename):
         requirements_filename,
         session=PipSession(),
     ):
-        log.debug('found requirement: %s', requirement.name)
-        explicit.add(canonicalize_name(requirement.name))
+        try:
+            requirement_name = requirement.name
+        # The type of "requirement" changed between pip versions.
+        # We exclude the "except" from coverage so that on any pip version we
+        # can report 100% coverage.
+        except AttributeError:  # pragma: no cover
+            requirement_name = requirement.requirement
+
+        log.debug('found requirement: %s', requirement_name)
+        explicit.add(canonicalize_name(requirement_name))
 
     return [(name, used[name]) for name in used if name not in explicit]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 packaging
-# These versions are matched in the GitHub workflows CI.
-pip >= 10.0.1, <= 19
+# Pinned pip versions are matched in the GitHub workflows CI matrix.
+pip >= 10.0.1

--- a/tests/test_find_extra_reqs.py
+++ b/tests/test_find_extra_reqs.py
@@ -87,7 +87,7 @@ def test_main_failure(monkeypatch, caplog, fake_opts):
     caplog.set_level(logging.WARN)
 
     monkeypatch.setattr(find_extra_reqs, 'find_extra_reqs',
-                        lambda x: ['extra'])
+                        lambda options, requirements_filename: ['extra'])
 
     with pytest.raises(SystemExit) as excinfo:
         find_extra_reqs.main()
@@ -146,7 +146,11 @@ def test_logging_config(monkeypatch, caplog, verbose_cfg, debug_cfg, result):
 
     monkeypatch.setattr(optparse, 'OptionParser', FakeOptParse)
 
-    monkeypatch.setattr(find_extra_reqs, 'find_extra_reqs', lambda x: [])
+    monkeypatch.setattr(
+        find_extra_reqs,
+        'find_extra_reqs',
+        lambda options, requirements_filename: [],
+    )
     find_extra_reqs.main()
 
     for event in [(logging.DEBUG, 'debug'), (logging.INFO, 'info'),

--- a/tests/test_find_extra_reqs.py
+++ b/tests/test_find_extra_reqs.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 import collections
 import logging
 import optparse
+from pathlib import Path
 
 import pytest
 import pretend
@@ -37,7 +38,7 @@ def fake_opts():
     return FakeOptParse
 
 
-def test_find_extra_reqs(monkeypatch):
+def test_find_extra_reqs(monkeypatch, tmp_path: Path):
     imported_modules = dict(spam=common.FoundModule('spam',
                                                     'site-spam/spam.py',
                                                     [('ham.py', 1)]),
@@ -64,11 +65,8 @@ def test_find_extra_reqs(monkeypatch):
     monkeypatch.setattr(find_extra_reqs, 'search_packages_info',
                         pretend.call_recorder(lambda x: packages_info))
 
-    FakeReq = collections.namedtuple('FakeReq', ['name'])
-    requirements = [FakeReq('foobar')]
-    monkeypatch.setattr(
-        common, 'parse_requirements',
-        pretend.call_recorder(lambda a, session=None: requirements))
+    fake_requirements_file = tmp_path / 'requirements.txt'
+    fake_requirements_file.write_text('foobar==1')
 
     class options:
         def ignore_reqs(x, y):
@@ -76,7 +74,10 @@ def test_find_extra_reqs(monkeypatch):
 
     options = options()
 
-    result = find_extra_reqs.find_extra_reqs(options)
+    result = find_extra_reqs.find_extra_reqs(
+        options=options,
+        requirements_filename=str(fake_requirements_file),
+    )
     assert result == ['foobar']
 
 

--- a/tests/test_find_missing_reqs.py
+++ b/tests/test_find_missing_reqs.py
@@ -63,8 +63,13 @@ def test_find_missing_reqs(monkeypatch):
     monkeypatch.setattr(find_missing_reqs, 'search_packages_info',
                         pretend.call_recorder(lambda x: packages_info))
 
-    FakeReq = collections.namedtuple('FakeReq', ['name'])
-    requirements = [FakeReq('spam')]
+    fake_requirements_file_contents = dedent(
+        """\
+        spam
+        """
+    )
+    FakeReq = collections.namedtuple('FakeReq', [])
+    requirements = [FakeReq()]
     monkeypatch.setattr(
         find_missing_reqs, 'parse_requirements',
         pretend.call_recorder(lambda a, session=None: requirements))

--- a/tests/test_find_missing_reqs.py
+++ b/tests/test_find_missing_reqs.py
@@ -65,7 +65,7 @@ def test_find_missing_reqs(monkeypatch, tmp_path: Path):
                         pretend.call_recorder(lambda x: packages_info))
 
     fake_requirements_file = tmp_path / 'requirements.txt'
-    fake_requirements_file.write_text('spam')
+    fake_requirements_file.write_text('spam==1')
 
     result = list(
         find_missing_reqs.find_missing_reqs(


### PR DESCRIPTION
This change adds support for the latest `pip` version at the time of writing (20.1.1).
Tests are now run nightly on the oldest supported and the latest version of `pip`.

It also fixes issues required to support that with the current tested functionality (not all functionality, but there is progress!).

With thanks to @Czaki for #23 which provided code and inspiration for some of this change.

Fixes #24 .

Fixes #21 .

Fixes #6 . (I believe - it fixes one case reported there and I cannot reproduce the other).