### PR TITLE
Make any built wheel explicitly not support Python 2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Release History
 ---------------
 
+2.1.1
+
+- Bug fix: Though Python 2 support was removed from the source code, the published wheel was still universal.
+  The published wheel now explicitly does not support Python 2.
+  Please use version 2.0.4 for Python 2.
+
 2.1.0
 
 - Remove support for Python 2.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,0 @@
-[bdist_wheel]
-# This flag says that the code is written to work on both Python 2 and Python
-# 3. If at all possible, it is good practice to do this. If you cannot, you
-# will need to generate wheels for each Python version that you support.
-universal=1


### PR DESCRIPTION
Relates to #41.