### PR TITLE
Do not fail CI if Codecov upload fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,4 +51,4 @@ jobs:
       - name: "Upload coverage to Codecov"
         uses: "codecov/codecov-action@v1"
         with:
-          fail_ci_if_error: true
+          fail_ci_if_error: false


### PR DESCRIPTION
This works around https://github.com/codecov/codecov-action/issues/37.