### PR TITLE
Include test-requirements.txt in the source tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,4 +4,5 @@ include LICENSE
 include setup.*
 include tox.ini
 include requirements.txt
+include test-requirements.txt
 include MANIFEST


### PR DESCRIPTION
Without this, running `pybuild --clean` fails with the following error:
```
$ pybuild --clean
I: pybuild base:217: python3.8 setup.py clean 
Traceback (most recent call last):
  File "setup.py", line 31, in <module>
    DEV_REQUIRES = _get_dependencies(
  File "setup.py", line 17, in _get_dependencies
    lines = requirements_file.read_text().strip().split('\n')
  File "/usr/lib/python3.8/pathlib.py", line 1232, in read_text
    with self.open(mode='r', encoding=encoding, errors=errors) as f:
  File "/usr/lib/python3.8/pathlib.py", line 1218, in open
    return io.open(self, mode, buffering, encoding, errors, newline,
  File "/usr/lib/python3.8/pathlib.py", line 1074, in _opener
    return self._accessor.open(self, flags, mode)
FileNotFoundError: [Errno 2] No such file or directory: 'test-requirements.txt'
E: pybuild pybuild:352: clean: plugin distutils failed with: exit code=1: python3.8 setup.py clean 
```