### PR TITLE
Set log level globally, not just in the script

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Release History
 - Added `--requirements-file` flag to `pip-extra-reqs` and `pip-missing-reqs`
   commands. This flag makes it possible to specify a path to the requirements
   file. Previously, `"requirements.txt"` was always used.
+- Fixed some of the logs not being visible with `-d` and `-v` flags.
 
 2.1.1
 

--- a/pip_check_reqs/find_extra_reqs.py
+++ b/pip_check_reqs/find_extra_reqs.py
@@ -122,11 +122,13 @@ def main():
 
     logging.basicConfig(format='%(message)s')
     if options.debug:
-        log.setLevel(logging.DEBUG)
+        level = logging.DEBUG
     elif options.verbose:
-        log.setLevel(logging.INFO)
+        level = logging.INFO
     else:
-        log.setLevel(logging.WARN)
+        level = logging.WARN
+    log.setLevel(level)
+    common.log.setLevel(level)
 
     log.info('using pip_check_reqs-%s from %s', __version__, __file__)
 

--- a/pip_check_reqs/find_missing_reqs.py
+++ b/pip_check_reqs/find_missing_reqs.py
@@ -136,11 +136,13 @@ def main():
 
     logging.basicConfig(format='%(message)s')
     if options.debug:
-        log.setLevel(logging.DEBUG)
+        level = logging.DEBUG
     elif options.verbose:
-        log.setLevel(logging.INFO)
+        level = logging.INFO
     else:
-        log.setLevel(logging.WARN)
+        level = logging.WARN
+    log.setLevel(level)
+    common.log.setLevel(level)
 
     log.info('using pip_check_reqs-%s from %s', __version__, __file__)
 


### PR DESCRIPTION
Fixes logging: previously, the log level set inside `pip-extra-reqs` and `pip-missing-reqs` via `-v` and `-d` flags wasn't propagated to `pip_check_reqs.common` module, making the logging there silent.