### PR TITLE
Add --skip-incompatible flag

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,9 @@ Release History
 
 2.2.0
 
+- Added `--skip-incompatible` flag to `pip-extra-reqs`, which makes it ignore
+  requirements with environment markers that are incompatible with the current
+  environment.
 - Added `--requirements-file` flag to `pip-extra-reqs` and `pip-missing-reqs`
   commands. This flag makes it possible to specify a path to the requirements
   file. Previously, `"requirements.txt"` was always used.

--- a/pip_check_reqs/find_extra_reqs.py
+++ b/pip_check_reqs/find_extra_reqs.py
@@ -87,6 +87,13 @@ def main():
                       action="append",
                       default=[],
                       help="reqs in requirements to ignore")
+    parser.add_option("-s",
+                      "--skip-incompatible",
+                      dest="skip_incompatible",
+                      action="store_true",
+                      default=False,
+                      help="skip requirements that have incompatible "
+                           "environment markers")
     parser.add_option("-v",
                       "--verbose",
                       dest="verbose",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-packaging
+packaging >= 16.0
 # Pinned pip versions are matched in the GitHub workflows CI matrix.
 pip >= 10.0.1

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -165,7 +165,7 @@ def test_ignorer(monkeypatch, tmp_path: Path, ignore_cfg, candidate, result):
 
 def test_find_required_modules(monkeypatch, tmp_path: Path):
     class options:
-        pass
+        skip_incompatible = False
 
     options.ignore_reqs = common.ignorer(ignore_cfg=['barfoo'])
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -177,3 +177,22 @@ def test_find_required_modules(monkeypatch, tmp_path: Path):
         requirements_filename=str(fake_requirements_file),
     )
     assert reqs == set(['foobar'])
+
+
+def test_find_required_modules_env_markers(monkeypatch, tmp_path):
+    class options:
+        skip_incompatible = True
+
+        def ignore_reqs(self, modname):
+            return False
+
+    fake_requirements_file = tmp_path / 'requirements.txt'
+    fake_requirements_file.write_text('spam==1; python_version<"2.0"\n'
+                                      'ham==2;\n'
+                                      'eggs==3\n')
+
+    reqs = common.find_required_modules(
+        options=options(),
+        requirements_filename=str(fake_requirements_file),
+    )
+    assert not reqs

--- a/tests/test_find_extra_reqs.py
+++ b/tests/test_find_extra_reqs.py
@@ -72,6 +72,7 @@ def test_find_extra_reqs(monkeypatch, tmp_path: Path):
     class options:
         def ignore_reqs(x, y):
             return False
+        skip_incompatible = False
 
     options = options()
 


### PR DESCRIPTION
This flag makes it possible to skip requirements that are incompatible
with the current environment, i.e. those whose PEP-496 environment
markers do not evaluate thruthly.

For example, when running Python 3.5, previously there would be no way
of processing the following requirement properly:

```
enum34; python_version<"3.4"
```

Ignoring it via `-r` is a bit heavy handed, as it means that it would no
longer get checked when running e.g. Python 2.7.

By using `-s` or `--skip-incompatible`, this requirement gets ignored
when running python versions 3.4 and above, but evaluated when running
on earlier versions.