### PR TITLE
chore: fix none package name

### DIFF
--- a/pip_check_reqs/common.py
+++ b/pip_check_reqs/common.py
@@ -155,7 +155,7 @@ def find_required_modules(options, requirements_filename: str):
         else:
             log.debug('found requirement: %s', requirement_name)
             if requirement_name:
-	            explicit.add(canonicalize_name(requirement_name))
+                explicit.add(canonicalize_name(requirement_name))
 
     return explicit
 

--- a/pip_check_reqs/common.py
+++ b/pip_check_reqs/common.py
@@ -154,7 +154,8 @@ def find_required_modules(options, requirements_filename: str):
 
         else:
             log.debug('found requirement: %s', requirement_name)
-            explicit.add(canonicalize_name(requirement_name))
+            if requirement_name:
+	    	explicit.add(canonicalize_name(requirement_name))
 
     return explicit
 

--- a/pip_check_reqs/common.py
+++ b/pip_check_reqs/common.py
@@ -155,7 +155,7 @@ def find_required_modules(options, requirements_filename: str):
         else:
             log.debug('found requirement: %s', requirement_name)
             if requirement_name:
-	        explicit.add(canonicalize_name(requirement_name))
+	            explicit.add(canonicalize_name(requirement_name))
 
     return explicit
 

--- a/pip_check_reqs/common.py
+++ b/pip_check_reqs/common.py
@@ -155,7 +155,7 @@ def find_required_modules(options, requirements_filename: str):
         else:
             log.debug('found requirement: %s', requirement_name)
             if requirement_name:
-	    	explicit.add(canonicalize_name(requirement_name))
+	        explicit.add(canonicalize_name(requirement_name))
 
     return explicit
 


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.6/bin/pip-extra-reqs", line 11, in <module>
    sys.exit(main())
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/pip_check_reqs/find_extra_reqs.py", line 144, in main
    requirements_filename=options.requirements_filename,
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/pip_check_reqs/find_extra_reqs.py", line 55, in find_extra_reqs
    requirements_filename=requirements_filename,
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/pip_check_reqs/common.py", line 157, in find_required_modules
    explicit.add(canonicalize_name(requirement_name))
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/packaging/utils.py", line 34, in canonicalize_name
    value = _canonicalize_regex.sub("-", name).lower()
TypeError: expected string or bytes-like object

```