### PR TITLE
Item location relative to package, not 'here'

### DIFF
--- a/pip_check_reqs/find_extra_reqs.py
+++ b/pip_check_reqs/find_extra_reqs.py
@@ -31,11 +31,10 @@ def find_extra_reqs(options, requirements_filename):
             package_location = package.location
             package_files = []
             for item in (package.files or []):
-                here = pathlib.Path('.').resolve()
                 item_location_rel = (pathlib.Path(package_location) / item)
                 item_location = item_location_rel.resolve()
                 try:
-                    relative_item_location = item_location.relative_to(here)
+                    relative_item_location = item_location.relative_to(package_location)
                 except ValueError:
                     # Ideally we would use Pathlib.is_relative_to rather than
                     # checking for a ValueError, but that is only available in


### PR DESCRIPTION
Previously, find_extra_reqs would concatenate the package_location with the file_location for a library import. This fails when using a virtualenv, because the package_location and the file_location end up sharing paths. This PR changes the file_location to be relative to the package, so that you get an actual file path. 

Fixes #75.