### PR TITLE
Added pip-compatible metadata for supported Python versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python :: 3',
     ],
-    python_requires='>=3.0',
+    python_requires=">=3.6.1",
     packages=['pip_check_reqs'],
     entry_points={
         'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python :: 3',
     ],
+    python_requires='>=3.0',
     packages=['pip_check_reqs'],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
This PR addresses issue #77.
For details, see the commit message.