### PR TITLE
Add testing strategies to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,8 @@ jobs:
         # These versions match the minimum and maximum versions of pip in
         # requirements.txt.
         # An empty string here represents the latest version.
-        pip-version: ['==10.0.1', '']
-        python-version: [3.6, 3.7, 3.8]
+        pip-version: ['==10.0.1', '==21.2.4', '']
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Aiming to ensure support for Python 3.9.
Also adds tests for pip pre-21.3, as a "just in case", see #74.