### PR TITLE
Fix duplicated line

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,6 @@ Basic usage, running in your project directory::
 
     <activate virtualenv for your project>
     pip-missing-reqs --ignore-file=sample/tests/* sample
-    pip-extra-reqs --ignore-file=sample/tests/* sample
 
 This will find all imports in the code in "sample" and check that the
 packages those modules belong to are in the requirements.txt file.


### PR DESCRIPTION
Removed example line for 'pip-extra-reqs', since it is in the sample for 'pip-missing-reqs'. 