### PR TITLE
Fix outdated changelog note

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,10 +2,11 @@
 Release History
 ---------------
 
-(unreleased)
+2.4.2
 
+- Added support for Python 3.11.
 - Added `python_requires` to metadata; from now on, releases of
-  `pip-check-reqs` are marked as compatible with Python 3.6.1 and up.
+  `pip-check-reqs` are marked as compatible with Python 3.8.0 and up.
 - Made `--version` flag show interpretter version and path to the package which
   pip-check-reqs is running from, similar to information shown by `pip
   --version`.


### PR DESCRIPTION
The items here are no longer "unreleased".
The note I made about compatibility with 3.6.2 was made obsolete in bcfd93ce187a9bef59c099c49324b66e57b7c7dd.