### PR TITLE
Remove redundant code paths

### DIFF
--- a/pip_check_reqs/find_extra_reqs.py
+++ b/pip_check_reqs/find_extra_reqs.py
@@ -27,26 +27,21 @@ def find_extra_reqs(options, requirements_filename):
     )
 
     for package in search_packages_info(all_pkgs):
-        if isinstance(package, dict):  # pragma: no cover
-            package_name = package['name']
-            package_location = package['location']
-            package_files = package.get('files', []) or []
-        else:  # pragma: no cover
-            package_name = package.name
-            package_location = package.location
-            package_files = []
-            for item in (package.files or []):
-                here = pathlib.Path('.').resolve()
-                item_location_rel = (pathlib.Path(package_location) / item)
-                item_location = item_location_rel.resolve()
-                try:
-                    relative_item_location = item_location.relative_to(here)
-                except ValueError:
-                    # Ideally we would use Pathlib.is_relative_to rather than
-                    # checking for a ValueError, but that is only available in
-                    # Python 3.9+.
-                    relative_item_location = item_location
-                package_files.append(str(relative_item_location))
+        package_name = package.name
+        package_location = package.location
+        package_files = []
+        for item in (package.files or []):
+            here = pathlib.Path('.').resolve()
+            item_location_rel = (pathlib.Path(package_location) / item)
+            item_location = item_location_rel.resolve()
+            try:
+                relative_item_location = item_location.relative_to(here)
+            except ValueError:
+                # Ideally we would use Pathlib.is_relative_to rather than
+                # checking for a ValueError, but that is only available in
+                # Python 3.9+.
+                relative_item_location = item_location
+            package_files.append(str(relative_item_location))
 
         log.debug('installed package: %s (at %s)', package_name,
                   package_location)

--- a/pip_check_reqs/find_missing_reqs.py
+++ b/pip_check_reqs/find_missing_reqs.py
@@ -31,26 +31,21 @@ def find_missing_reqs(options, requirements_filename):
     )
 
     for package in search_packages_info(all_pkgs):
-        if isinstance(package, dict):  # pragma: no cover
-            package_name = package['name']
-            package_location = package['location']
-            package_files = package.get('files', []) or []
-        else:  # pragma: no cover
-            package_name = package.name
-            package_location = package.location
-            package_files = []
-            for item in (package.files or []):
-                here = pathlib.Path('.').resolve()
-                item_location_rel = (pathlib.Path(package_location) / item)
-                item_location = item_location_rel.resolve()
-                try:
-                    relative_item_location = item_location.relative_to(here)
-                except ValueError:
-                    # Ideally we would use Pathlib.is_relative_to rather than
-                    # checking for a ValueError, but that is only available in
-                    # Python 3.9+.
-                    relative_item_location = item_location
-                package_files.append(str(relative_item_location))
+        package_name = package.name
+        package_location = package.location
+        package_files = []
+        for item in (package.files or []):
+            here = pathlib.Path('.').resolve()
+            item_location_rel = (pathlib.Path(package_location) / item)
+            item_location = item_location_rel.resolve()
+            try:
+                relative_item_location = item_location.relative_to(here)
+            except ValueError:
+                # Ideally we would use Pathlib.is_relative_to rather than
+                # checking for a ValueError, but that is only available in
+                # Python 3.9+.
+                relative_item_location = item_location
+            package_files.append(str(relative_item_location))
 
         log.debug('installed package: %s (at %s)', package_name,
                   package_location)

--- a/tests/package_info_mock.py
+++ b/tests/package_info_mock.py
@@ -1,0 +1,9 @@
+from typing import List, Optional, NamedTuple
+
+
+# A stand-in for pip._internal.commands.show._PackageInfo, as returned by
+# search_packages_info from the same module
+class _PackageInfo(NamedTuple):
+    name: str
+    location: str
+    files: Optional[List[str]]

--- a/tests/test_find_extra_reqs.py
+++ b/tests/test_find_extra_reqs.py
@@ -12,6 +12,8 @@ import pretend
 
 from pip_check_reqs import find_extra_reqs, common
 
+from .package_info_mock import _PackageInfo
+
 
 @pytest.fixture
 def fake_opts():
@@ -68,11 +70,10 @@ def test_find_extra_reqs(monkeypatch, tmp_path: Path):
         pretend.call_recorder(lambda **kwargs: installed_distributions),
     )
     packages_info = [
-        dict(name='spam',
-             location='site-spam',
-             files=['spam/__init__.py', 'spam/shrub.py']),
-        dict(name='shrub', location='site-spam', files=['shrub.py']),
-        dict(name='pass', location='site-spam', files=['pass.py']),
+        _PackageInfo(name='spam', location='site-spam',
+                     files=['spam/__init__.py', 'spam/shrub.py']),
+        _PackageInfo(name='shrub', location='site-spam', files=['shrub.py']),
+        _PackageInfo(name='pass', location='site-spam', files=['pass.py']),
     ]
 
     monkeypatch.setattr(find_extra_reqs, 'search_packages_info',


### PR DESCRIPTION
We are now constrained on `pip >= 21.2.4` (bcfd93ce). This elliminates code paths that were there previously in order to cater to the older versions of Pip:

- `PipSession` is now only found in `pip._internal._network.session`.
- `install_req_from_line` is always used.
- `search_packages_info` now always gives us a generator that yields `pip._internal.commands.show._PackageInfo` objects (not `dict`).