### PR TITLE
ImportVisitor: skip all relative imports

### DIFF
--- a/pip_check_reqs/common.py
+++ b/pip_check_reqs/common.py
@@ -50,7 +50,7 @@ class ImportVisitor(ast.NodeVisitor):
             # not an actual module
             return
         for alias in node.names:
-            if node.module is None:
+            if node.module is None or node.level != 0:
                 # relative import
                 continue
             self._addModule(node.module + "." + alias.name, node.lineno)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -49,6 +49,8 @@ def test_FoundModule() -> None:
         ("from string import hexdigits", ["string"]),
         ("import distutils.command.check", ["distutils.command.check"]),
         ("import spam", []),  # don't break because bad programmer
+        ("from .foo import bar", []),  # don't break on relative imports
+        ("from . import baz", []),
     ],
 )
 def test_ImportVisitor(stmt: str, result: List[str]) -> None:


### PR DESCRIPTION
This commit is a step towards detecting when a package is not installed. Currently, `pip-check-reqs` will silently skip them, even if they are actually extra/missing in the project requirements.

---

Checking just `node.module` is not sufficient for detecting a relative imports. It only finds relative imports of the form:

```
from . import foo
```

It misses imports of the following form:

```
from .foo import bar
from .....more_dots import baz
```

... letting the execution pass these to the `_addModule`. This fails with `ImportError` at `imp.find_module`, because the parameters given to it to not include the dots from the import statement.

This makes the `ImportError` less useful to us, if we would like to use it to detect requirements that aren't installed. Right now, `pip-missing-reqs` will silently skip missing installs, which contributes to significant user confusion.