### PR TITLE
Switch a few `str` representations of paths to `pathlib.Path`

### DIFF
--- a/pip_check_reqs/common.py
+++ b/pip_check_reqs/common.py
@@ -124,15 +124,14 @@ class _ImportVisitor(ast.NodeVisitor):
         return result
 
 
-def pyfiles(root: str) -> Generator[str, None, None]:
-    root_path = Path(root)
-    if root_path.is_file():
-        if root_path.suffix == ".py":
-            yield str(root_path.absolute())
+def pyfiles(root: Path) -> Generator[str, None, None]:
+    if root.is_file():
+        if root.suffix == ".py":
+            yield str(root.absolute())
         else:
-            raise ValueError(f"{root_path} is not a python file or directory")
-    elif root_path.is_dir():
-        for item in root_path.rglob("*.py"):
+            raise ValueError(f"{root} is not a python file or directory")
+    elif root.is_dir():
+        for item in root.rglob("*.py"):
             yield str(item.absolute())
 
 
@@ -143,7 +142,7 @@ def find_imported_modules(
 ) -> Dict[str, FoundModule]:
     vis = _ImportVisitor(ignore_modules_function=ignore_modules_function)
     for path in paths:
-        for filename in pyfiles(path):
+        for filename in pyfiles(Path(path)):
             if ignore_files_function(filename):
                 log.info("ignoring: %s", os.path.relpath(filename))
                 continue

--- a/pip_check_reqs/common.py
+++ b/pip_check_reqs/common.py
@@ -159,11 +159,11 @@ def find_required_modules(
         [Union[str, ParsedRequirement]], bool
     ],
     skip_incompatible: bool,
-    requirements_filename: str,
+    requirements_filename: Path,
 ) -> Set[NormalizedName]:
     explicit = set()
     for requirement in parse_requirements(
-        requirements_filename, session=PipSession()
+        str(requirements_filename), session=PipSession()
     ):
         requirement_name = install_req_from_line(
             requirement.requirement,

--- a/pip_check_reqs/common.py
+++ b/pip_check_reqs/common.py
@@ -136,13 +136,13 @@ def pyfiles(root: Path) -> Generator[str, None, None]:
 
 
 def find_imported_modules(
-    paths: Iterable[str],
+    paths: Iterable[Path],
     ignore_files_function: Callable[[str], bool],
     ignore_modules_function: Callable[[str], bool],
 ) -> Dict[str, FoundModule]:
     vis = _ImportVisitor(ignore_modules_function=ignore_modules_function)
     for path in paths:
-        for filename in pyfiles(Path(path)):
+        for filename in pyfiles(path):
             if ignore_files_function(filename):
                 log.info("ignoring: %s", os.path.relpath(filename))
                 continue

--- a/pip_check_reqs/find_extra_reqs.py
+++ b/pip_check_reqs/find_extra_reqs.py
@@ -5,8 +5,8 @@ import collections
 import importlib.metadata
 import logging
 import os
-import pathlib
 import sys
+from pathlib import Path
 from typing import Callable, Iterable, List, Optional, Union
 
 from packaging.utils import canonicalize_name
@@ -21,7 +21,7 @@ log = logging.getLogger(__name__)
 
 def find_extra_reqs(
     requirements_filename: str,
-    paths: Iterable[str],
+    paths: Iterable[Path],
     ignore_files_function: Callable[[str], bool],
     ignore_modules_function: Callable[[str], bool],
     ignore_requirements_function: Callable[
@@ -48,8 +48,8 @@ def find_extra_reqs(
         package_location = package.location
         package_files = []
         for item in package.files or []:
-            here = pathlib.Path(".").resolve()
-            item_location_rel = pathlib.Path(package_location) / item
+            here = Path(".").resolve()
+            item_location_rel = Path(package_location) / item
             item_location = item_location_rel.resolve()
             try:
                 relative_item_location = item_location.relative_to(here)
@@ -109,7 +109,7 @@ def main(arguments: Optional[List[str]] = None) -> None:
     """Main entry point."""
     usage = "usage: %prog [options] files or directories"
     parser = argparse.ArgumentParser(usage)
-    parser.add_argument("paths", nargs="*")
+    parser.add_argument("paths", type=Path, nargs="*")
     parser.add_argument(
         "--requirements-file",
         dest="requirements_filename",

--- a/pip_check_reqs/find_extra_reqs.py
+++ b/pip_check_reqs/find_extra_reqs.py
@@ -20,7 +20,7 @@ log = logging.getLogger(__name__)
 
 
 def find_extra_reqs(
-    requirements_filename: str,
+    requirements_filename: Path,
     paths: Iterable[Path],
     ignore_files_function: Callable[[str], bool],
     ignore_modules_function: Callable[[str], bool],
@@ -113,8 +113,9 @@ def main(arguments: Optional[List[str]] = None) -> None:
     parser.add_argument(
         "--requirements-file",
         dest="requirements_filename",
+        type=Path,
         metavar="PATH",
-        default="requirements.txt",
+        default=Path("requirements.txt"),
         help="path to the requirements file "
         '(defaults to "requirements.txt")',
     )

--- a/pip_check_reqs/find_missing_reqs.py
+++ b/pip_check_reqs/find_missing_reqs.py
@@ -22,7 +22,7 @@ log = logging.getLogger(__name__)
 
 
 def find_missing_reqs(
-    requirements_filename: str,
+    requirements_filename: Path,
     paths: Iterable[Path],
     ignore_files_function: Callable[[str], bool],
     ignore_modules_function: Callable[[str], bool],
@@ -95,7 +95,7 @@ def find_missing_reqs(
     # 4. compare with requirements
     explicit = set()
     for requirement in parse_requirements(
-        requirements_filename,
+        str(requirements_filename),
         session=PipSession(),
     ):
         requirement_name = install_req_from_line(
@@ -118,6 +118,7 @@ def main(arguments: Optional[List[str]] = None) -> None:
         "--requirements-file",
         dest="requirements_filename",
         metavar="PATH",
+        type=Path,
         default="requirements.txt",
         help="path to the requirements file "
         '(defaults to "requirements.txt")',

--- a/pip_check_reqs/find_missing_reqs.py
+++ b/pip_check_reqs/find_missing_reqs.py
@@ -5,8 +5,8 @@ import collections
 import importlib.metadata
 import logging
 import os
-import pathlib
 import sys
+from pathlib import Path
 from typing import Callable, Iterable, List, Optional, Tuple
 
 from packaging.utils import NormalizedName, canonicalize_name
@@ -23,7 +23,7 @@ log = logging.getLogger(__name__)
 
 def find_missing_reqs(
     requirements_filename: str,
-    paths: Iterable[str],
+    paths: Iterable[Path],
     ignore_files_function: Callable[[str], bool],
     ignore_modules_function: Callable[[str], bool],
 ) -> List[Tuple[NormalizedName, List[FoundModule]]]:
@@ -46,8 +46,8 @@ def find_missing_reqs(
         package_location = package.location
         package_files = []
         for item in package.files or []:
-            here = pathlib.Path(".").resolve()
-            item_location_rel = pathlib.Path(package_location) / item
+            here = Path(".").resolve()
+            item_location_rel = Path(package_location) / item
             item_location = item_location_rel.resolve()
             try:
                 relative_item_location = item_location.relative_to(here)
@@ -113,7 +113,7 @@ def find_missing_reqs(
 def main(arguments: Optional[List[str]] = None) -> None:
     usage = "usage: %prog [options] files or directories"
     parser = argparse.ArgumentParser(usage)
-    parser.add_argument("paths", nargs="*")
+    parser.add_argument("paths", type=Path, nargs="*")
     parser.add_argument(
         "--requirements-file",
         dest="requirements_filename",

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -204,7 +204,7 @@ def test_find_required_modules(tmp_path: Path) -> None:
     reqs = common.find_required_modules(
         ignore_requirements_function=common.ignorer(ignore_cfg=["barfoo"]),
         skip_incompatible=False,
-        requirements_filename=str(fake_requirements_file),
+        requirements_filename=fake_requirements_file,
     )
     assert reqs == {"foobar"}
 
@@ -218,7 +218,7 @@ def test_find_required_modules_env_markers(tmp_path: Path) -> None:
     reqs = common.find_required_modules(
         ignore_requirements_function=common.ignorer(ignore_cfg=[]),
         skip_incompatible=True,
-        requirements_filename=str(fake_requirements_file),
+        requirements_filename=fake_requirements_file,
     )
     assert reqs == {"ham", "eggs"}
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -156,7 +156,7 @@ def test_find_imported_modules(
         return False
 
     result = common.find_imported_modules(
-        paths=[str(root)],
+        paths=[root],
         ignore_files_function=ignore_files,
         ignore_modules_function=ignore_mods,
     )
@@ -241,7 +241,7 @@ def test_find_imported_modules_sets_encoding_to_utf8_when_reading(
 
     monkeypatch.setattr(builtins, "open", mocked_open)
     common.find_imported_modules(
-        paths=[str(tmp_path)],
+        paths=[tmp_path],
         ignore_files_function=common.ignorer(ignore_cfg=[]),
         ignore_modules_function=common.ignorer(ignore_cfg=[]),
     )

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -36,7 +36,7 @@ def test_is_package_file(path: str, result: str) -> None:
 def test_found_module() -> None:
     found_module = common.FoundModule("spam", "ham")
     assert found_module.modname == "spam"
-    assert found_module.filename == os.path.realpath("ham")
+    assert found_module.filename == str(Path("ham").resolve())
     assert found_module.locations == []
 
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -66,7 +66,7 @@ def test_import_visitor(stmt: str, result: List[str]) -> None:
 def test_pyfiles_file(tmp_path: Path) -> None:
     python_file = tmp_path / "example.py"
     python_file.touch()
-    assert list(common.pyfiles(root=str(python_file))) == [str(python_file)]
+    assert list(common.pyfiles(root=python_file)) == [str(python_file)]
 
 
 def test_pyfiles_file_no_dice(tmp_path: Path) -> None:
@@ -74,7 +74,7 @@ def test_pyfiles_file_no_dice(tmp_path: Path) -> None:
     not_python_file.touch()
 
     with pytest.raises(ValueError):
-        list(common.pyfiles(root=str(not_python_file)))
+        list(common.pyfiles(root=not_python_file))
 
 
 def test_pyfiles_package(tmp_path: Path) -> None:
@@ -88,7 +88,7 @@ def test_pyfiles_package(tmp_path: Path) -> None:
 
     not_python_file.touch()
 
-    assert list(common.pyfiles(root=str(tmp_path))) == [
+    assert list(common.pyfiles(root=tmp_path)) == [
         str(python_file),
         str(nested_python_file),
     ]

--- a/tests/test_find_extra_reqs.py
+++ b/tests/test_find_extra_reqs.py
@@ -43,7 +43,7 @@ def test_find_extra_reqs(tmp_path: Path) -> None:
 
     result = find_extra_reqs.find_extra_reqs(
         requirements_filename=str(fake_requirements_file),
-        paths=[str(source_dir)],
+        paths=[source_dir],
         ignore_files_function=common.ignorer(ignore_cfg=[]),
         ignore_modules_function=common.ignorer(ignore_cfg=[]),
         ignore_requirements_function=common.ignorer(ignore_cfg=[]),

--- a/tests/test_find_extra_reqs.py
+++ b/tests/test_find_extra_reqs.py
@@ -42,7 +42,7 @@ def test_find_extra_reqs(tmp_path: Path) -> None:
     )
 
     result = find_extra_reqs.find_extra_reqs(
-        requirements_filename=str(fake_requirements_file),
+        requirements_filename=fake_requirements_file,
         paths=[source_dir],
         ignore_files_function=common.ignorer(ignore_cfg=[]),
         ignore_modules_function=common.ignorer(ignore_cfg=[]),

--- a/tests/test_find_missing_reqs.py
+++ b/tests/test_find_missing_reqs.py
@@ -43,7 +43,7 @@ def test_find_missing_reqs(tmp_path: Path) -> None:
     )
 
     result = find_missing_reqs.find_missing_reqs(
-        requirements_filename=str(fake_requirements_file),
+        requirements_filename=fake_requirements_file,
         paths=[source_dir],
         ignore_files_function=common.ignorer(ignore_cfg=[]),
         ignore_modules_function=common.ignorer(ignore_cfg=[]),

--- a/tests/test_find_missing_reqs.py
+++ b/tests/test_find_missing_reqs.py
@@ -44,7 +44,7 @@ def test_find_missing_reqs(tmp_path: Path) -> None:
 
     result = find_missing_reqs.find_missing_reqs(
         requirements_filename=str(fake_requirements_file),
-        paths=[str(source_dir)],
+        paths=[source_dir],
         ignore_files_function=common.ignorer(ignore_cfg=[]),
         ignore_modules_function=common.ignorer(ignore_cfg=[]),
     )


### PR DESCRIPTION
This is part of a wider goal in #97 to switch from `os.path` to `pathlib.Path`.