### PR TITLE
Make pyfiles generate paths rather than strings

### DIFF
--- a/pip_check_reqs/common.py
+++ b/pip_check_reqs/common.py
@@ -124,15 +124,15 @@ class _ImportVisitor(ast.NodeVisitor):
         return result
 
 
-def pyfiles(root: Path) -> Generator[str, None, None]:
+def pyfiles(root: Path) -> Generator[Path, None, None]:
     if root.is_file():
         if root.suffix == ".py":
-            yield str(root.absolute())
+            yield root.absolute()
         else:
             raise ValueError(f"{root} is not a python file or directory")
     elif root.is_dir():
         for item in root.rglob("*.py"):
-            yield str(item.absolute())
+            yield item.absolute()
 
 
 def find_imported_modules(
@@ -143,14 +143,14 @@ def find_imported_modules(
     vis = _ImportVisitor(ignore_modules_function=ignore_modules_function)
     for path in paths:
         for filename in pyfiles(path):
-            if ignore_files_function(filename):
+            if ignore_files_function(str(filename)):
                 log.info("ignoring: %s", os.path.relpath(filename))
                 continue
             log.debug("scanning: %s", os.path.relpath(filename))
             with open(filename, encoding="utf-8") as file_obj:
                 content = file_obj.read()
-            vis.set_location(filename)
-            vis.visit(ast.parse(content, filename))
+            vis.set_location(str(filename))
+            vis.visit(ast.parse(content, str(filename)))
     return vis.finalise()
 
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -66,7 +66,7 @@ def test_import_visitor(stmt: str, result: List[str]) -> None:
 def test_pyfiles_file(tmp_path: Path) -> None:
     python_file = tmp_path / "example.py"
     python_file.touch()
-    assert list(common.pyfiles(root=python_file)) == [str(python_file)]
+    assert list(common.pyfiles(root=python_file)) == [python_file]
 
 
 def test_pyfiles_file_no_dice(tmp_path: Path) -> None:
@@ -89,8 +89,8 @@ def test_pyfiles_package(tmp_path: Path) -> None:
     not_python_file.touch()
 
     assert list(common.pyfiles(root=tmp_path)) == [
-        str(python_file),
-        str(nested_python_file),
+        python_file,
+        nested_python_file,
     ]
 
 


### PR DESCRIPTION
This is part of a wider goal in #97 to switch from `os.path` to `pathlib.Path`.