### PR TITLE
Switch from isort and flake8 to ruff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,9 +55,8 @@ jobs:
 
       - name: "Lint"
         run: |
-          flake8 *.py pip_check_reqs tests
           mypy .
-          isort --check-only .
+          ruff .
           black --check .
           pylint pip_check_reqs tests
           pip-extra-reqs pip_check_reqs

--- a/pip_check_reqs/common.py
+++ b/pip_check_reqs/common.py
@@ -1,3 +1,4 @@
+
 """Common functions."""
 
 import ast

--- a/pip_check_reqs/common.py
+++ b/pip_check_reqs/common.py
@@ -1,4 +1,3 @@
-
 """Common functions."""
 
 from __future__ import annotations
@@ -52,7 +51,7 @@ class _ImportVisitor(ast.NodeVisitor):
         self._location = location
 
     # Ignore the name error as we are overriding the method.
-    def visit_Import(  # pylint: disable=invalid-name
+    def visit_Import(  # noqa: N802, pylint: disable=invalid-name
         self,
         node: ast.Import,
     ) -> None:
@@ -60,7 +59,7 @@ class _ImportVisitor(ast.NodeVisitor):
             self._add_module(alias.name, node.lineno)
 
     # Ignore the name error as we are overriding the method.
-    def visit_ImportFrom(  # pylint: disable=invalid-name
+    def visit_ImportFrom(  # noqa: N802, pylint: disable=invalid-name
         self,
         node: ast.ImportFrom,
     ) -> None:
@@ -145,7 +144,6 @@ def find_imported_modules(
                 continue
             log.debug("scanning: %s", os.path.relpath(filename))
             content = filename.read_text(encoding="utf-8")
-            # with open(filename, encoding="utf-8") as file_obj:
             vis.set_location(str(filename))
             vis.visit(ast.parse(content, str(filename)))
     return vis.finalise()
@@ -154,14 +152,16 @@ def find_imported_modules(
 def find_required_modules(
     *,
     ignore_requirements_function: Callable[
-        [str | ParsedRequirement], bool,
+        [str | ParsedRequirement],
+        bool,
     ],
     skip_incompatible: bool,
     requirements_filename: Path,
 ) -> set[NormalizedName]:
     explicit = set()
     for requirement in parse_requirements(
-        str(requirements_filename), session=PipSession(),
+        str(requirements_filename),
+        session=PipSession(),
     ):
         requirement_name = install_req_from_line(
             requirement.requirement,

--- a/pip_check_reqs/common.py
+++ b/pip_check_reqs/common.py
@@ -120,8 +120,7 @@ class _ImportVisitor(ast.NodeVisitor):
         self._modules[modname].locations.append((self._location, lineno))
 
     def finalise(self) -> Dict[str, FoundModule]:
-        result = self._modules
-        return result
+        return self._modules
 
 
 def pyfiles(root: Path) -> Generator[Path, None, None]:
@@ -129,7 +128,8 @@ def pyfiles(root: Path) -> Generator[Path, None, None]:
         if root.suffix == ".py":
             yield root.absolute()
         else:
-            raise ValueError(f"{root} is not a python file or directory")
+            msg = f"{root} is not a python file or directory"
+            raise ValueError(msg)
     elif root.is_dir():
         for item in root.rglob("*.py"):
             yield item.absolute()
@@ -156,14 +156,14 @@ def find_imported_modules(
 
 def find_required_modules(
     ignore_requirements_function: Callable[
-        [Union[str, ParsedRequirement]], bool
+        [Union[str, ParsedRequirement]], bool,
     ],
     skip_incompatible: bool,
     requirements_filename: Path,
 ) -> Set[NormalizedName]:
     explicit = set()
     for requirement in parse_requirements(
-        str(requirements_filename), session=PipSession()
+        str(requirements_filename), session=PipSession(),
     ):
         requirement_name = install_req_from_line(
             requirement.requirement,

--- a/pip_check_reqs/common.py
+++ b/pip_check_reqs/common.py
@@ -1,6 +1,8 @@
 
 """Common functions."""
 
+from __future__ import annotations
+
 import ast
 import fnmatch
 import imp
@@ -12,14 +14,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import (
     Callable,
-    Dict,
     Generator,
     Iterable,
-    List,
-    Optional,
-    Set,
-    Tuple,
-    Union,
 )
 
 from packaging.markers import Marker
@@ -39,7 +35,7 @@ class FoundModule:
 
     modname: str
     filename: str
-    locations: List[Tuple[str, int]] = field(default_factory=list)
+    locations: list[tuple[str, int]] = field(default_factory=list)
 
     def __post_init__(self) -> None:
         self.filename = os.path.realpath(self.filename)
@@ -49,8 +45,8 @@ class _ImportVisitor(ast.NodeVisitor):
     def __init__(self, ignore_modules_function: Callable[[str], bool]) -> None:
         super().__init__()
         self._ignore_modules_function = ignore_modules_function
-        self._modules: Dict[str, FoundModule] = {}
-        self._location: Optional[str] = None
+        self._modules: dict[str, FoundModule] = {}
+        self._location: str | None = None
 
     def set_location(self, location: str) -> None:
         self._location = location
@@ -120,7 +116,7 @@ class _ImportVisitor(ast.NodeVisitor):
         assert isinstance(self._location, str)
         self._modules[modname].locations.append((self._location, lineno))
 
-    def finalise(self) -> Dict[str, FoundModule]:
+    def finalise(self) -> dict[str, FoundModule]:
         return self._modules
 
 
@@ -140,7 +136,7 @@ def find_imported_modules(
     paths: Iterable[Path],
     ignore_files_function: Callable[[str], bool],
     ignore_modules_function: Callable[[str], bool],
-) -> Dict[str, FoundModule]:
+) -> dict[str, FoundModule]:
     vis = _ImportVisitor(ignore_modules_function=ignore_modules_function)
     for path in paths:
         for filename in pyfiles(path):
@@ -157,11 +153,11 @@ def find_imported_modules(
 
 def find_required_modules(
     ignore_requirements_function: Callable[
-        [Union[str, ParsedRequirement]], bool,
+        [str | ParsedRequirement], bool,
     ],
     skip_incompatible: bool,
     requirements_filename: Path,
-) -> Set[NormalizedName]:
+) -> set[NormalizedName]:
     explicit = set()
     for requirement in parse_requirements(
         str(requirements_filename), session=PipSession(),
@@ -212,13 +208,13 @@ def is_package_file(path: str) -> str:
     return ""
 
 
-def ignorer(ignore_cfg: List[str]) -> Callable[..., bool]:
+def ignorer(ignore_cfg: list[str]) -> Callable[..., bool]:
     if not ignore_cfg:
         return lambda candidate: False
 
     def ignorer_function(
-        candidate: Union[str, ParsedRequirement],
-        ignore_cfg: List[str] = ignore_cfg,
+        candidate: str | ParsedRequirement,
+        ignore_cfg: list[str] = ignore_cfg,
     ) -> bool:
         for ignore in ignore_cfg:
             if isinstance(candidate, str):

--- a/pip_check_reqs/find_extra_reqs.py
+++ b/pip_check_reqs/find_extra_reqs.py
@@ -1,5 +1,7 @@
 """Find extra requirements."""
 
+from __future__ import annotations
+
 import argparse
 import collections
 import importlib.metadata
@@ -7,15 +9,17 @@ import logging
 import os
 import sys
 from pathlib import Path
-from typing import Callable, Iterable, List, Optional, Union
+from typing import TYPE_CHECKING, Callable, Iterable
 from unittest import mock
 
 from packaging.utils import canonicalize_name
 from pip._internal.commands.show import search_packages_info
-from pip._internal.req.req_file import ParsedRequirement
 
 from pip_check_reqs import common
 from pip_check_reqs.common import version_info
+
+if TYPE_CHECKING:
+    from pip._internal.req.req_file import ParsedRequirement
 
 log = logging.getLogger(__name__)
 
@@ -26,10 +30,10 @@ def find_extra_reqs(
     ignore_files_function: Callable[[str], bool],
     ignore_modules_function: Callable[[str], bool],
     ignore_requirements_function: Callable[
-        [Union[str, ParsedRequirement]], bool,
+        [str | ParsedRequirement], bool,
     ],
     skip_incompatible: bool,
-) -> List[str]:
+) -> list[str]:
     # 1. find files used by imports in the code (as best we can without
     #    executing)
     used_modules = common.find_imported_modules(
@@ -112,7 +116,7 @@ def find_extra_reqs(
     return [name for name in explicit if name not in used]
 
 
-def main(arguments: Optional[List[str]] = None) -> None:
+def main(arguments: list[str] | None = None) -> None:
     """Main entry point."""
     usage = "usage: %prog [options] files or directories"
     parser = argparse.ArgumentParser(usage)

--- a/pip_check_reqs/find_extra_reqs.py
+++ b/pip_check_reqs/find_extra_reqs.py
@@ -26,7 +26,7 @@ def find_extra_reqs(
     ignore_files_function: Callable[[str], bool],
     ignore_modules_function: Callable[[str], bool],
     ignore_requirements_function: Callable[
-        [Union[str, ParsedRequirement]], bool
+        [Union[str, ParsedRequirement]], bool,
     ],
     skip_incompatible: bool,
 ) -> List[str]:
@@ -55,7 +55,7 @@ def find_extra_reqs(
         package_location = package.location
         package_files = []
         for item in package.files or []:
-            here = Path(".").resolve()
+            here = Path().resolve()
             item_location_rel = Path(package_location) / item
             item_location = item_location_rel.resolve()
             try:
@@ -68,7 +68,7 @@ def find_extra_reqs(
             package_files.append(str(relative_item_location))
 
         log.debug(
-            "installed package: %s (at %s)", package_name, package_location
+            "installed package: %s (at %s)", package_name, package_location,
         )
         for package_file in package_files:
             path = os.path.realpath(
@@ -156,7 +156,7 @@ def main(arguments: Optional[List[str]] = None) -> None:
         dest="skip_incompatible",
         action="store_true",
         default=False,
-        help="skip requirements that have incompatible " "environment markers",
+        help="skip requirements that have incompatible environment markers",
     )
     parser.add_argument(
         "-v",

--- a/pip_check_reqs/find_extra_reqs.py
+++ b/pip_check_reqs/find_extra_reqs.py
@@ -31,7 +31,8 @@ def find_extra_reqs(
     ignore_files_function: Callable[[str], bool],
     ignore_modules_function: Callable[[str], bool],
     ignore_requirements_function: Callable[
-        [str | ParsedRequirement], bool,
+        [str | ParsedRequirement],
+        bool,
     ],
     skip_incompatible: bool,
 ) -> list[str]:
@@ -73,7 +74,9 @@ def find_extra_reqs(
             package_files.append(str(relative_item_location))
 
         log.debug(
-            "installed package: %s (at %s)", package_name, package_location,
+            "installed package: %s (at %s)",
+            package_name,
+            package_location,
         )
         for package_file in package_files:
             path = os.path.realpath(

--- a/pip_check_reqs/find_extra_reqs.py
+++ b/pip_check_reqs/find_extra_reqs.py
@@ -25,6 +25,7 @@ log = logging.getLogger(__name__)
 
 
 def find_extra_reqs(
+    *,
     requirements_filename: Path,
     paths: Iterable[Path],
     ignore_files_function: Callable[[str], bool],

--- a/pip_check_reqs/find_extra_reqs.py
+++ b/pip_check_reqs/find_extra_reqs.py
@@ -77,7 +77,7 @@ def find_extra_reqs(
         )
         for package_file in package_files:
             path = os.path.realpath(
-                os.path.join(package_location, package_file),
+                Path(package_location) / package_file,
             )
             installed_files[path] = package_name
             package_path = common.is_package_file(path)
@@ -118,7 +118,7 @@ def find_extra_reqs(
 
 
 def main(arguments: list[str] | None = None) -> None:
-    """Main entry point."""
+    """pip-extra-reqs entry point."""
     usage = "usage: %prog [options] files or directories"
     parser = argparse.ArgumentParser(usage)
     parser.add_argument("paths", type=Path, nargs="*")
@@ -191,7 +191,7 @@ def main(arguments: list[str] | None = None) -> None:
     parse_result = parser.parse_args(arguments)
 
     if parse_result.version:
-        print(version_info())
+        sys.stdout.write(version_info() + "\n")
         sys.exit(0)
 
     if not parse_result.paths:

--- a/pip_check_reqs/find_missing_reqs.py
+++ b/pip_check_reqs/find_missing_reqs.py
@@ -1,5 +1,7 @@
 """Find missing requirements."""
 
+from __future__ import annotations
+
 import argparse
 import collections
 import importlib.metadata
@@ -7,7 +9,7 @@ import logging
 import os
 import sys
 from pathlib import Path
-from typing import Callable, Iterable, List, Optional, Tuple
+from typing import Callable, Iterable
 from unittest import mock
 
 from packaging.utils import NormalizedName, canonicalize_name
@@ -27,7 +29,7 @@ def find_missing_reqs(
     paths: Iterable[Path],
     ignore_files_function: Callable[[str], bool],
     ignore_modules_function: Callable[[str], bool],
-) -> List[Tuple[NormalizedName, List[FoundModule]]]:
+) -> list[tuple[NormalizedName, list[FoundModule]]]:
     # 1. find files used by imports in the code (as best we can without
     #    executing)
     used_modules = common.find_imported_modules(
@@ -70,7 +72,7 @@ def find_missing_reqs(
         )
         for package_file in package_files:
             path = os.path.realpath(
-                os.path.join(package_location, package_file),
+                str(Path(package_location) / package_file),
             )
             installed_files[path] = package_name
             package_path = common.is_package_file(path)
@@ -116,7 +118,7 @@ def find_missing_reqs(
     return [(name, used[name]) for name in used if name not in explicit]
 
 
-def main(arguments: Optional[List[str]] = None) -> None:
+def main(arguments: list[str] | None = None) -> None:
     usage = "usage: %prog [options] files or directories"
     parser = argparse.ArgumentParser(usage)
     parser.add_argument("paths", type=Path, nargs="*")
@@ -173,7 +175,7 @@ def main(arguments: Optional[List[str]] = None) -> None:
     parse_result = parser.parse_args(arguments)
 
     if parse_result.version:
-        print(version_info())
+        sys.stdout.write(version_info() + "\n")
         sys.exit(0)
 
     if not parse_result.paths:

--- a/pip_check_reqs/find_missing_reqs.py
+++ b/pip_check_reqs/find_missing_reqs.py
@@ -68,7 +68,9 @@ def find_missing_reqs(
             package_files.append(str(relative_item_location))
 
         log.debug(
-            "installed package: %s (at %s)", package_name, package_location,
+            "installed package: %s (at %s)",
+            package_name,
+            package_location,
         )
         for package_file in package_files:
             path = os.path.realpath(

--- a/pip_check_reqs/find_missing_reqs.py
+++ b/pip_check_reqs/find_missing_reqs.py
@@ -53,7 +53,7 @@ def find_missing_reqs(
         package_location = package.location
         package_files = []
         for item in package.files or []:
-            here = Path(".").resolve()
+            here = Path().resolve()
             item_location_rel = Path(package_location) / item
             item_location = item_location_rel.resolve()
             try:
@@ -66,7 +66,7 @@ def find_missing_reqs(
             package_files.append(str(relative_item_location))
 
         log.debug(
-            "installed package: %s (at %s)", package_name, package_location
+            "installed package: %s (at %s)", package_name, package_location,
         )
         for package_file in package_files:
             path = os.path.realpath(
@@ -113,8 +113,7 @@ def find_missing_reqs(
         log.debug("found requirement: %s", requirement_name)
         explicit.add(canonicalize_name(requirement_name))
 
-    result = [(name, used[name]) for name in used if name not in explicit]
-    return result
+    return [(name, used[name]) for name in used if name not in explicit]
 
 
 def main(arguments: Optional[List[str]] = None) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,9 +48,9 @@
         'too-many-return-statements',
         'too-many-lines',
         'locally-disabled',
-        # Let flake8 handle long lines
+        # Let ruff handle long lines
         'line-too-long',
-        # Let flake8 handle unused imports
+        # Let ruff handle unused imports
         'unused-import',
         # Let isort deal with sorting
         'ungrouped-imports',
@@ -59,7 +59,7 @@
         'missing-return-type-doc',
         # Too difficult to please
         'duplicate-code',
-        # Let isort handle imports
+        # Let ruff handle imports
         'wrong-import-order',
         # It would be nice to add this, but it's too much work
         "missing-function-docstring",
@@ -94,7 +94,5 @@ line-length = 79
 
 strict = true
 
-[tool.isort]
-
-multi_line_output = 3
-include_trailing_comma = true
+[tool.ruff]
+select = ["ALL"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,9 @@ line-length = 79
 strict = true
 
 [tool.ruff]
+
+target-version = "py38"
+
 select = ["ALL"]
 
 ignore = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,9 +101,20 @@ target-version = "py38"
 select = ["ALL"]
 
 ignore = [
+    # We do not annotate the type of 'self', or 'cls'.
+    "ANN101",
+    # We are missing too many docstrings to quickly fix now.
+    "D100",
+    "D103",
+    "D104",
+    "D105",
+    "D203",
+    "D213",
     # Allow 'assert' in tests as it is the standard for pytest.
     # Also, allow 'assert' in other code as it is the standard for Python type hint
     # narrowing - see
     # https://mypy.readthedocs.io/en/stable/type_narrowing.html#type-narrowing-expressions.
     "S101",
 ]
+
+line-length = 79

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,8 @@ ignore = [
     "D105",
     "D203",
     "D213",
+    # Allow functions to take as many arguments as they want.
+    "PLR0913",
     # Allow 'assert' in tests as it is the standard for pytest.
     # Also, allow 'assert' in other code as it is the standard for Python type hint
     # narrowing - see

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,3 +96,11 @@ strict = true
 
 [tool.ruff]
 select = ["ALL"]
+
+ignore = [
+    # Allow 'assert' in tests as it is the standard for pytest.
+    # Also, allow 'assert' in other code as it is the standard for Python type hint
+    # narrowing - see
+    # https://mypy.readthedocs.io/en/stable/type_narrowing.html#type-narrowing-expressions.
+    "S101",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,3 +120,10 @@ ignore = [
 ]
 
 line-length = 79
+
+[tool.coverage.report]
+
+exclude_lines =  [
+  "pragma: no cover",
+  "if TYPE_CHECKING:",
+]

--- a/setup.py
+++ b/setup.py
@@ -1,28 +1,28 @@
-from codecs import open
-from os import path
+from __future__ import annotations
+
 from pathlib import Path
-from typing import List
 
 from setuptools import setup
 
 from pip_check_reqs import __version__
 
-here = path.abspath(path.dirname(__file__))
+here = Path.resolve(Path(__file__).parent)
 
 
-def _get_dependencies(requirements_file: Path) -> List[str]:
+def _get_dependencies(requirements_file: Path) -> list[str]:
     """Return requirements from a requirements file.
+
     This expects a requirements file with no ``--find-links`` lines.
     """
     lines = requirements_file.read_text().strip().split("\n")
     return [line for line in lines if not line.startswith("#")]
 
 
-with open(path.join(here, "README.rst"), encoding="utf-8") as f:
-    long_description = f.read()
-
-with open(path.join(here, "CHANGELOG.rst"), encoding="utf-8") as f:
-    long_description += f.read()
+readme = here / "README.rst"
+readme_content = readme.read_text(encoding="utf-8")
+changelog = here / "CHANGELOG.rst"
+changelog_content = changelog.read_text(encoding="utf-8")
+long_description = readme_content + "\n\n" + changelog_content
 
 INSTALL_REQUIRES = _get_dependencies(
     requirements_file=Path("requirements.txt"),

--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,7 @@ here = path.abspath(path.dirname(__file__))
 
 
 def _get_dependencies(requirements_file: Path) -> List[str]:
-    """
-    Return requirements from a requirements file.
+    """Return requirements from a requirements file.
     This expects a requirements file with no ``--find-links`` lines.
     """
     lines = requirements_file.read_text().strip().split("\n")

--- a/spelling_private_dict.txt
+++ b/spelling_private_dict.txt
@@ -1,1 +1,3 @@
 pragma
+reqs
+

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,5 @@
 black
-flake8
-isort
+ruff
 mypy
 pyenchant
 pylint

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -17,7 +17,7 @@ from pip_check_reqs import __version__, common
 
 
 @pytest.mark.parametrize(
-    ["path", "result"],
+    ("path", "result"),
     [
         ("/", ""),
         ("__init__.py", ""),  # a top-level file like this has no package name
@@ -41,7 +41,7 @@ def test_found_module() -> None:
 
 
 @pytest.mark.parametrize(
-    ["stmt", "result"],
+    ("stmt", "result"),
     [
         ("import ast", ["ast"]),
         ("import ast, pathlib", ["ast", "pathlib"]),
@@ -98,7 +98,7 @@ def test_pyfiles_package(tmp_path: Path) -> None:
 # See the comment in the implementation.
 # We don't mind so much as we only really use this for third party packages.
 @pytest.mark.parametrize(
-    ["ignore_ham", "ignore_hashlib", "expect", "locs"],
+    ("ignore_ham", "ignore_hashlib", "expect", "locs"),
     [
         (
             False,
@@ -173,7 +173,7 @@ def test_find_imported_modules(
 
 
 @pytest.mark.parametrize(
-    ["ignore_cfg", "candidate", "result"],
+    ("ignore_cfg", "candidate", "result"),
     [
         ([], "spam", False),
         ([], "ham", False),

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -70,7 +70,10 @@ def test_pyfiles_file_no_dice(tmp_path: Path) -> None:
     not_python_file = tmp_path / "example"
     not_python_file.touch()
 
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        expected_exception=ValueError,
+        match=f"{not_python_file} is not a python file or directory",
+    ):
         list(common.pyfiles(root=not_python_file))
 
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -34,7 +34,7 @@ def test_found_module() -> None:
     found_module = common.FoundModule("spam", "ham")
     assert found_module.modname == "spam"
     assert found_module.filename == str(Path("ham").resolve())
-    assert found_module.locations == []
+    assert not found_module.locations
 
 
 @pytest.mark.parametrize(
@@ -51,7 +51,7 @@ def test_found_module() -> None:
     ],
 )
 def test_import_visitor(stmt: str, result: list[str]) -> None:
-    vis = common._ImportVisitor(  # pylint: disable=protected-access
+    vis = common._ImportVisitor(  # noqa: SLF001,E501, pylint: disable=protected-access
         ignore_modules_function=common.ignorer(ignore_cfg=[]),
     )
     vis.set_location("spam.py")
@@ -188,6 +188,7 @@ def test_find_imported_modules(
     ],
 )
 def test_ignorer(
+    *,
     monkeypatch: pytest.MonkeyPatch,
     ignore_cfg: list[str],
     candidate: str,

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,5 +1,6 @@
 """Tests for `common.py`."""
 
+from __future__ import annotations
 
 import ast
 import builtins
@@ -8,7 +9,7 @@ import os.path
 import textwrap
 from copy import copy
 from pathlib import Path
-from typing import Any, List, Tuple
+from typing import Any
 
 import pytest
 from pytest import MonkeyPatch
@@ -53,7 +54,7 @@ def test_found_module() -> None:
         ("from . import baz", []),
     ],
 )
-def test_import_visitor(stmt: str, result: List[str]) -> None:
+def test_import_visitor(stmt: str, result: list[str]) -> None:
     vis = common._ImportVisitor(  # pylint: disable=protected-access
         ignore_modules_function=common.ignorer(ignore_cfg=[]),
     )
@@ -118,8 +119,8 @@ def test_find_imported_modules(
     caplog: pytest.LogCaptureFixture,
     ignore_ham: bool,
     ignore_hashlib: bool,
-    expect: List[str],
-    locs: List[Tuple[str, int]],
+    expect: list[str],
+    locs: list[tuple[str, int]],
     tmp_path: Path,
 ) -> None:
     root = tmp_path
@@ -188,7 +189,7 @@ def test_find_imported_modules(
 )
 def test_ignorer(
     monkeypatch: MonkeyPatch,
-    ignore_cfg: List[str],
+    ignore_cfg: list[str],
     candidate: str,
     result: bool,
 ) -> None:

--- a/tests/test_find_extra_reqs.py
+++ b/tests/test_find_extra_reqs.py
@@ -23,7 +23,7 @@ def test_find_extra_reqs(tmp_path: Path) -> None:
             not_installed_package_12345==1
             {installed_imported_required_package.__name__}
             {installed_not_imported_required_package.__name__}
-            """
+            """,
         ),
     )
 
@@ -37,7 +37,7 @@ def test_find_extra_reqs(tmp_path: Path) -> None:
             import pprint
 
             import {installed_imported_required_package.__name__}
-            """
+            """,
         ),
     )
 
@@ -93,7 +93,7 @@ def test_main_no_spec(capsys: pytest.CaptureFixture[str]) -> None:
 
 
 @pytest.mark.parametrize(
-    ["verbose_cfg", "debug_cfg", "expected_log_levels"],
+    ("verbose_cfg", "debug_cfg", "expected_log_levels"),
     [
         (False, False, {logging.WARNING}),
         (True, False, {logging.INFO, logging.WARNING}),

--- a/tests/test_find_extra_reqs.py
+++ b/tests/test_find_extra_reqs.py
@@ -1,15 +1,18 @@
 """Tests for `find_extra_reqs.py`."""
 
+from __future__ import annotations
 
 import logging
 import textwrap
-from pathlib import Path
-from typing import Set
+from typing import TYPE_CHECKING
 
 import black
 import pytest
 
 from pip_check_reqs import common, find_extra_reqs
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def test_find_extra_reqs(tmp_path: Path) -> None:
@@ -87,26 +90,28 @@ def test_main_no_spec(capsys: pytest.CaptureFixture[str]) -> None:
     with pytest.raises(SystemExit) as excinfo:
         find_extra_reqs.main(arguments=[])
 
-    assert excinfo.value.code == 2
+    expected_code = 2
+    assert excinfo.value.code == expected_code
     err = capsys.readouterr().err
     assert err.endswith("error: no source files or directories specified\n")
 
 
 @pytest.mark.parametrize(
-    ("verbose_cfg", "debug_cfg", "expected_log_levels"),
+    ("expected_log_levels", "verbose_cfg", "debug_cfg"),
     [
-        (False, False, {logging.WARNING}),
-        (True, False, {logging.INFO, logging.WARNING}),
-        (False, True, {logging.DEBUG, logging.INFO, logging.WARNING}),
-        (True, True, {logging.DEBUG, logging.INFO, logging.WARNING}),
+        ({logging.WARNING}, False, False),
+        ({logging.INFO, logging.WARNING}, True, False),
+        ({logging.DEBUG, logging.INFO, logging.WARNING}, False, True),
+        ({logging.DEBUG, logging.INFO, logging.WARNING}, True, True),
     ],
 )
 def test_logging_config(
     caplog: pytest.LogCaptureFixture,
+    expected_log_levels: set[int],
+    tmp_path: Path,
+    *,
     verbose_cfg: bool,
     debug_cfg: bool,
-    expected_log_levels: Set[int],
-    tmp_path: Path,
 ) -> None:
     source_dir = tmp_path / "source"
     source_dir.mkdir()

--- a/tests/test_find_missing_reqs.py
+++ b/tests/test_find_missing_reqs.py
@@ -23,7 +23,7 @@ def test_find_missing_reqs(tmp_path: Path) -> None:
             f"""\
             not_installed_package_12345==1
             {installed_imported_required_package.__name__}
-            """
+            """,
         ),
     )
 
@@ -38,7 +38,7 @@ def test_find_missing_reqs(tmp_path: Path) -> None:
 
             import {installed_imported_not_required_package.__name__}
             import {installed_imported_required_package.__name__}
-            """
+            """,
         ),
     )
 
@@ -56,8 +56,8 @@ def test_find_missing_reqs(tmp_path: Path) -> None:
                     modname=installed_imported_not_required_package.__name__,
                     filename=str(
                         Path(
-                            installed_imported_not_required_package.__file__
-                        ).parent
+                            installed_imported_not_required_package.__file__,
+                        ).parent,
                     ),
                     locations=[(str(source_file), 3)],
                 ),
@@ -113,7 +113,7 @@ def test_main_no_spec(capsys: pytest.CaptureFixture[str]) -> None:
 
 
 @pytest.mark.parametrize(
-    ["verbose_cfg", "debug_cfg", "expected_log_levels"],
+    ("verbose_cfg", "debug_cfg", "expected_log_levels"),
     [
         (False, False, {logging.WARNING}),
         (True, False, {logging.INFO, logging.WARNING}),

--- a/tests/test_find_missing_reqs.py
+++ b/tests/test_find_missing_reqs.py
@@ -6,7 +6,6 @@ import logging
 import os
 import textwrap
 from pathlib import Path
-from typing import Set
 
 import black
 import pytest
@@ -97,7 +96,7 @@ def test_main_failure(
     assert excinfo.value.code == 1
 
     assert caplog.records[0].message == "Missing requirements:"
-    relative_source_file = os.path.relpath(source_file, os.getcwd())
+    relative_source_file = os.path.relpath(source_file, Path.cwd())
     assert (
         caplog.records[1].message
         == f"{relative_source_file}:1 dist=pytest module=pytest"
@@ -128,7 +127,7 @@ def test_logging_config(
     caplog: pytest.LogCaptureFixture,
     verbose_cfg: bool,
     debug_cfg: bool,
-    expected_log_levels: Set[int],
+    expected_log_levels: set[int],
     tmp_path: Path,
 ) -> None:
     source_dir = tmp_path / "source"

--- a/tests/test_find_missing_reqs.py
+++ b/tests/test_find_missing_reqs.py
@@ -107,7 +107,8 @@ def test_main_no_spec(capsys: pytest.CaptureFixture[str]) -> None:
     with pytest.raises(SystemExit) as excinfo:
         find_missing_reqs.main(arguments=[])
 
-    assert excinfo.value.code == 2
+    expected_code = 2
+    assert excinfo.value.code == expected_code
     err = capsys.readouterr().err
     assert err.endswith("error: no source files or directories specified\n")
 

--- a/tests/test_find_missing_reqs.py
+++ b/tests/test_find_missing_reqs.py
@@ -1,5 +1,6 @@
 """Tests for `find_missing_reqs.py`."""
 
+from __future__ import annotations
 
 import logging
 import os
@@ -123,6 +124,7 @@ def test_main_no_spec(capsys: pytest.CaptureFixture[str]) -> None:
     ],
 )
 def test_logging_config(
+    *,
     caplog: pytest.LogCaptureFixture,
     verbose_cfg: bool,
     debug_cfg: bool,


### PR DESCRIPTION
Ruff is faster, more comprehensive, and has a `--fix` option (unlike flake8).