### PR TITLE
Use/require keyword arguments in more function calls

### DIFF
--- a/pip_check_reqs/common.py
+++ b/pip_check_reqs/common.py
@@ -47,7 +47,7 @@ class _ImportVisitor(ast.NodeVisitor):
         self._modules: dict[str, FoundModule] = {}
         self._location: str | None = None
 
-    def set_location(self, location: str) -> None:
+    def set_location(self, *, location: str) -> None:
         self._location = location
 
     # Ignore the name error as we are overriding the method.
@@ -121,6 +121,7 @@ def pyfiles(root: Path) -> Generator[Path, None, None]:
 
 
 def find_imported_modules(
+    *,
     paths: Iterable[Path],
     ignore_files_function: Callable[[str], bool],
     ignore_modules_function: Callable[[str], bool],
@@ -133,7 +134,7 @@ def find_imported_modules(
                 continue
             log.debug("scanning: %s", os.path.relpath(filename))
             content = filename.read_text(encoding="utf-8")
-            vis.set_location(str(filename))
+            vis.set_location(location=str(filename))
             vis.visit(ast.parse(content, str(filename)))
     return vis.finalise()
 
@@ -163,7 +164,7 @@ def find_required_modules(
 
         if skip_incompatible:
             requirement_string = requirement.requirement
-            if not has_compatible_markers(requirement_string):
+            if not has_compatible_markers(full_requirement=requirement_string):
                 log.debug(
                     "ignoring requirement (incompatible environment "
                     "marker): %s",
@@ -177,7 +178,7 @@ def find_required_modules(
     return explicit
 
 
-def has_compatible_markers(full_requirement: str) -> bool:
+def has_compatible_markers(*, full_requirement: str) -> bool:
     if ";" not in full_requirement:
         return True  # No environment marker.
 
@@ -188,7 +189,7 @@ def has_compatible_markers(full_requirement: str) -> bool:
     return Marker(enviroment_marker).evaluate()
 
 
-def is_package_file(path: str) -> str:
+def is_package_file(*, path: str) -> str:
     """Determine whether the path points to a Python package sentinel file.
 
     A sentinel file is the __init__.py or its compiled variants.
@@ -199,7 +200,7 @@ def is_package_file(path: str) -> str:
     return ""
 
 
-def ignorer(ignore_cfg: list[str]) -> Callable[..., bool]:
+def ignorer(*, ignore_cfg: list[str]) -> Callable[..., bool]:
     if not ignore_cfg:
         return lambda _: False
 

--- a/pip_check_reqs/find_extra_reqs.py
+++ b/pip_check_reqs/find_extra_reqs.py
@@ -83,7 +83,7 @@ def find_extra_reqs(
                 Path(package_location) / package_file,
             )
             installed_files[path] = package_name
-            package_path = common.is_package_file(path)
+            package_path = common.is_package_file(path=path)
             if package_path:
                 # we've seen a package file so add the bare package directory
                 # to the installed list as well as we might want to look up
@@ -200,9 +200,9 @@ def main(arguments: list[str] | None = None) -> None:
     if not parse_result.paths:
         parser.error("no source files or directories specified")
 
-    ignore_files = common.ignorer(parse_result.ignore_files)
-    ignore_mods = common.ignorer(parse_result.ignore_mods)
-    ignore_reqs = common.ignorer(parse_result.ignore_reqs)
+    ignore_files = common.ignorer(ignore_cfg=parse_result.ignore_files)
+    ignore_mods = common.ignorer(ignore_cfg=parse_result.ignore_mods)
+    ignore_reqs = common.ignorer(ignore_cfg=parse_result.ignore_reqs)
 
     logging.basicConfig(format="%(message)s")
     if parse_result.debug:

--- a/pip_check_reqs/find_missing_reqs.py
+++ b/pip_check_reqs/find_missing_reqs.py
@@ -77,7 +77,7 @@ def find_missing_reqs(
                 str(Path(package_location) / package_file),
             )
             installed_files[path] = package_name
-            package_path = common.is_package_file(path)
+            package_path = common.is_package_file(path=path)
             if package_path:
                 # we've seen a package file so add the bare package directory
                 # to the installed list as well as we might want to look up
@@ -183,8 +183,8 @@ def main(arguments: list[str] | None = None) -> None:
     if not parse_result.paths:
         parser.error("no source files or directories specified")
 
-    ignore_files = common.ignorer(parse_result.ignore_files)
-    ignore_mods = common.ignorer(parse_result.ignore_mods)
+    ignore_files = common.ignorer(ignore_cfg=parse_result.ignore_files)
+    ignore_mods = common.ignorer(ignore_cfg=parse_result.ignore_mods)
 
     logging.basicConfig(format="%(message)s")
     if parse_result.debug:

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -32,7 +32,7 @@ def test_is_package_file(path: str, result: str) -> None:
 
 
 def test_found_module() -> None:
-    found_module = common.FoundModule("spam", "ham")
+    found_module = common.FoundModule(modname="spam", filename="ham")
     assert found_module.modname == "spam"
     assert found_module.filename == str(Path("ham").resolve())
     assert not found_module.locations

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -28,7 +28,7 @@ from pip_check_reqs import __version__, common
     ],
 )
 def test_is_package_file(path: str, result: str) -> None:
-    assert common.is_package_file(path) == result
+    assert common.is_package_file(path=path) == result
 
 
 def test_found_module() -> None:
@@ -56,7 +56,7 @@ def test_import_visitor(stmt: str, result: list[str]) -> None:
     vis = common._ImportVisitor(  # noqa: SLF001,E501, pylint: disable=protected-access
         ignore_modules_function=common.ignorer(ignore_cfg=[]),
     )
-    vis.set_location("spam.py")
+    vis.set_location(location="spam.py")
     vis.visit(ast.parse(stmt))
     finalise_result = vis.finalise()
     assert set(finalise_result.keys()) == set(result)
@@ -204,7 +204,7 @@ def test_ignorer(
     result: bool,
 ) -> None:
     monkeypatch.setattr(os.path, "relpath", lambda s: s.lstrip("/"))
-    ignorer = common.ignorer(ignore_cfg)
+    ignorer = common.ignorer(ignore_cfg=ignore_cfg)
     assert ignorer(candidate) == result
 
 


### PR DESCRIPTION
This makes `mypy` hints better as they now mention the keyword name, not just "Argument 2".