### PR TITLE
Do not use relative paths in logging. Removes all worries about relpa…

### DIFF
--- a/pip_check_reqs/common.py
+++ b/pip_check_reqs/common.py
@@ -143,9 +143,9 @@ def find_imported_modules(
     for path in paths:
         for filename in pyfiles(path):
             if ignore_files_function(str(filename)):
-                log.info("ignoring: %s", os.path.relpath(filename))
+                log.info("ignoring: %s", filename)
                 continue
-            log.debug("scanning: %s", os.path.relpath(filename))
+            log.debug("scanning: %s", filename)
             content = filename.read_text(encoding="utf-8")
             vis.set_location(location=str(filename))
             vis.visit(ast.parse(content, str(filename)))

--- a/pip_check_reqs/find_missing_reqs.py
+++ b/pip_check_reqs/find_missing_reqs.py
@@ -221,7 +221,7 @@ def main(arguments: list[str] | None = None) -> None:
             for filename, lineno in use.locations:
                 log.warning(
                     "%s:%s dist=%s module=%s",
-                    os.path.relpath(filename),
+                    filename,
                     lineno,
                     name,
                     use.modname,

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-import os.path
 import sys
 import textwrap
 from pathlib import Path
@@ -231,7 +230,7 @@ def test_find_imported_modules_advanced(
     assert sorted(relative_locations) == sorted(locs)
 
     if ignore_ham:
-        assert caplog.records[0].message == f"ignoring: {os.path.relpath(ham)}"
+        assert caplog.records[0].message == f"ignoring: {ham}"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_find_missing_reqs.py
+++ b/tests/test_find_missing_reqs.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-import os
 import textwrap
 from pathlib import Path
 
@@ -96,10 +95,9 @@ def test_main_failure(
     assert excinfo.value.code == 1
 
     assert caplog.records[0].message == "Missing requirements:"
-    relative_source_file = os.path.relpath(source_file, Path.cwd())
     assert (
         caplog.records[1].message
-        == f"{relative_source_file}:1 dist=pytest module=pytest"
+        == f"{source_file}:1 dist=pytest module=pytest"
     )
 
 


### PR DESCRIPTION
…ths breaking (e.g. if paths are on a different Windows drive