### PR TITLE
Standardise find_missing_reqs and find_extra_reqs on pathlib.Path.res…

### DIFF
--- a/pip_check_reqs/common.py
+++ b/pip_check_reqs/common.py
@@ -32,11 +32,11 @@ class FoundModule:
     """A module with uses in the source."""
 
     modname: str
-    filename: str
+    filename: Path
     locations: list[tuple[str, int]] = field(default_factory=list)
 
     def __post_init__(self) -> None:
-        self.filename = str(Path(self.filename).resolve())
+        self.filename = Path(self.filename).resolve()
 
 
 class _ImportVisitor(ast.NodeVisitor):
@@ -111,7 +111,7 @@ class _ImportVisitor(ast.NodeVisitor):
                         pass
                 self._modules[modname] = FoundModule(
                     modname=modname,
-                    filename=str(modpath_path),
+                    filename=modpath_path,
                 )
             assert isinstance(self._location, str)
             self._modules[modname].locations.append((self._location, lineno))
@@ -201,7 +201,7 @@ def has_compatible_markers(*, full_requirement: str) -> bool:
     return Marker(enviroment_marker).evaluate()
 
 
-def package_path(*, path: Path) -> str | None:
+def package_path(*, path: Path) -> Path | None:
     """Return the package path for a given Python package sentinel file.
 
     Return None if the path is not a sentinel file.
@@ -214,7 +214,7 @@ def package_path(*, path: Path) -> str | None:
     if path.name not in ("__init__.py", "__init__.pyc", "__init__.pyo"):
         return None
 
-    return str(path.parent)
+    return path.parent
 
 
 def ignorer(*, ignore_cfg: list[str]) -> Callable[..., bool]:

--- a/pip_check_reqs/find_extra_reqs.py
+++ b/pip_check_reqs/find_extra_reqs.py
@@ -88,11 +88,11 @@ def find_extra_reqs(
             package_location,
         )
         for package_file in package_files:
-            path = str(
-                (Path(package_location) / package_file).resolve(),
-            )
+            path = Path(package_location) / package_file
+            path = path.resolve()
+
             installed_files[path] = package_name
-            package_path = common.package_path(path=Path(path))
+            package_path = common.package_path(path=path)
             if package_path:
                 # we've seen a package file so add the bare package directory
                 # to the installed list as well as we might want to look up

--- a/pip_check_reqs/find_missing_reqs.py
+++ b/pip_check_reqs/find_missing_reqs.py
@@ -63,7 +63,7 @@ def find_missing_reqs(
     for package in packages_info:
         package_name = package.name
         package_location = package.location
-        package_files = []
+        package_files: list[str] = []
         for item in package.files or []:
             item_location_rel = Path(package_location) / item
             item_location = item_location_rel.resolve()
@@ -82,16 +82,16 @@ def find_missing_reqs(
             package_location,
         )
         for package_file in package_files:
-            path = os.path.realpath(
-                str(Path(package_location) / package_file),
-            )
+            path = Path(package_location) / package_file
+            path = path.resolve()
+
             installed_files[path] = package_name
-            package_path = common.package_path(path=Path(path))
+            package_path = common.package_path(path=path)
             if package_path:
                 # we've seen a package file so add the bare package directory
                 # to the installed list as well as we might want to look up
                 # a package by its directory path later
-                installed_files[package_path] = package_name
+                installed_files[str(package_path)] = package_name
 
     # 3. match imported modules against those packages
     used = collections.defaultdict(list)

--- a/pip_check_reqs/find_missing_reqs.py
+++ b/pip_check_reqs/find_missing_reqs.py
@@ -91,7 +91,7 @@ def find_missing_reqs(
                 # we've seen a package file so add the bare package directory
                 # to the installed list as well as we might want to look up
                 # a package by its directory path later
-                installed_files[str(package_path)] = package_name
+                installed_files[package_path] = package_name
 
     # 3. match imported modules against those packages
     used = collections.defaultdict(list)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -23,21 +23,21 @@ from pip_check_reqs import __version__, common
         # a top-level file like this has no package path
         (Path("__init__.py"), None),
         (Path("/__init__.py"), None),  # no package name
-        (Path("spam/__init__.py"), "spam"),
-        (Path("spam/__init__.pyc"), "spam"),
-        (Path("spam/__init__.pyo"), "spam"),
-        (Path("ham/spam/__init__.py"), "ham/spam"),
-        (Path("/ham/spam/__init__.py"), "/ham/spam"),
+        (Path("spam/__init__.py"), Path("spam")),
+        (Path("spam/__init__.pyc"), Path("spam")),
+        (Path("spam/__init__.pyo"), Path("spam")),
+        (Path("ham/spam/__init__.py"), Path("ham/spam")),
+        (Path("/ham/spam/__init__.py"), Path("/ham/spam")),
     ],
 )
-def test_package_path(path: Path, result: str) -> None:
+def test_package_path(path: Path, result: Path) -> None:
     assert common.package_path(path=path) == result, path
 
 
 def test_found_module() -> None:
-    found_module = common.FoundModule(modname="spam", filename="ham")
+    found_module = common.FoundModule(modname="spam", filename=Path("ham"))
     assert found_module.modname == "spam"
-    assert found_module.filename == str(Path("ham").resolve())
+    assert found_module.filename == Path("ham").resolve()
     assert not found_module.locations
 
 

--- a/tests/test_find_missing_reqs.py
+++ b/tests/test_find_missing_reqs.py
@@ -53,11 +53,9 @@ def test_find_missing_reqs(tmp_path: Path) -> None:
             [
                 common.FoundModule(
                     modname=installed_imported_not_required_package.__name__,
-                    filename=str(
-                        Path(
-                            installed_imported_not_required_package.__file__,
-                        ).parent,
-                    ),
+                    filename=Path(
+                        installed_imported_not_required_package.__file__,
+                    ).parent,
                     locations=[(str(source_file), 3)],
                 ),
             ],


### PR DESCRIPTION
…olve

Before, find_extra_reqs had both Path.resolve and os.path.relpath. and find_missing_reqs had only os.path.relpath.

This change brings them both to Path.resolve.
This may cause problems as os.path.relpath by default "walks up" the tree, as per resolve's "walk_up" parameter in Python 3.12.