### PR TITLE
Use bash shell for CI steps to ensure early failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           if [ "${{ matrix.os }}" = "windows-latest" ]; then
             uv venv C:/Users/runner/.venv
-            echo "activate=C:/Users/runner/.venv/Scripts/Activate.ps1" >> "$GITHUB_OUTPUT"
+            echo "activate=source C:/Users/runner/.venv/Scripts/activate" >> "$GITHUB_OUTPUT"
           else
             uv venv /home/runner/.venv
             echo "activate=source /home/runner/.venv/bin/activate" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,4 @@
 ---
-
 name: CI
 
 on:
@@ -10,14 +9,13 @@ on:
   schedule:
     # * is a special character in YAML so you have to quote this string
     # Run at 1:00 every day
-    - cron:  '0 1 * * *'
+    - cron: "0 1 * * *"
 
 jobs:
   build:
-
     strategy:
       matrix:
-        uv-resolution: ['highest', 'lowest']
+        uv-resolution: ["highest", "lowest"]
         # The minimum version should be represented in pyproject.toml.
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         os: [ubuntu-latest, windows-latest]
@@ -47,6 +45,9 @@ jobs:
         shell: bash
 
       - name: "Install dependencies"
+        # Use bash to ensure the step fails if any command fails.
+        # PowerShell does not fail on intermediate command failures by default.
+        shell: bash
         run: |
           ${{ steps.venv.outputs.activate }}
           # We want the latest dev requirements, but the lowest install requirements.
@@ -54,6 +55,9 @@ jobs:
           uv pip install --resolution=${{ matrix.uv-resolution }} --upgrade --editable .
 
       - name: "Lint"
+        # Use bash to ensure the step fails if any command fails.
+        # PowerShell does not fail on intermediate command failures by default.
+        shell: bash
         run: |
           ${{ steps.venv.outputs.activate }}
           mypy .
@@ -68,6 +72,9 @@ jobs:
           actionlint
 
       - name: "Run tests"
+        # Use bash to ensure the step fails if any command fails.
+        # PowerShell does not fail on intermediate command failures by default.
+        shell: bash
         run: |
           ${{ steps.venv.outputs.activate }}
           pytest -s -vvv --cov-fail-under 100 --cov=pip_check_reqs/ --cov=tests tests/ --cov-report=xml
@@ -75,7 +82,7 @@ jobs:
   completion-ci:
     needs: build
     runs-on: ubuntu-latest
-    if: always()  # Run even if one matrix job fails
+    if: always() # Run even if one matrix job fails
     steps:
       - name: Check matrix job status
         run: |


### PR DESCRIPTION
PowerShell does not fail on intermediate command failures by default. By using bash shell, we ensure that any failing command causes the step to fail immediately.

See https://github.com/adamtheturtle/doccmd/pull/720 for the original learning.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens CI reliability by ensuring steps fail on any command error and aligning virtualenv activation across OSes.
> 
> - Force `shell: bash` for `Install dependencies`, `Lint`, and `Run tests` steps
> - Change Windows venv activation to `source C:/Users/runner/.venv/Scripts/activate` in `Create virtual environment`
> - Normalize YAML quoting (cron, matrix values) and minor formatting; `completion-ci` condition unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6df6ec0ac145c7a2ae5f20fa9699ca8726a2145e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->