### PR TITLE
Simplify CI by using uv natively

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
 
       - name: "Install dependencies"
         run: |
+          uv venv ${{ env.UV_PROJECT_ENVIRONMENT }}
           # We want the latest dev requirements, but the lowest install requirements.
           uv pip install --upgrade --editable .[dev]
           uv pip install --resolution=${{ matrix.uv-resolution }} --upgrade --editable .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,9 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
+    env:
+      UV_PROJECT_ENVIRONMENT: .venv
+
     steps:
       - uses: actions/checkout@v6
 
@@ -34,26 +37,32 @@ jobs:
         run: uv venv
 
       - name: "Install dependencies"
+        shell: bash
         run: |
           # We want the latest dev requirements, but the lowest install requirements.
           uv pip install --upgrade --editable .[dev]
           uv pip install --resolution=${{ matrix.uv-resolution }} --upgrade --editable .
 
       - name: "Lint"
+        shell: bash
         run: |
-          uv run --no-sync mypy .
-          uv run --no-sync ruff check .
-          uv run --no-sync ruff format --check .
-          uv run --no-sync pip-extra-reqs pip_check_reqs
-          uv run --no-sync pip-missing-reqs pip_check_reqs
-          uv run --no-sync pylint pip_check_reqs tests
-          uv run --no-sync pyroma --min=10 .
-          uv run --no-sync pyproject-fmt --check .
-          uv run --no-sync pyright .
+          source .venv/bin/activate || source .venv/Scripts/activate
+          mypy .
+          ruff check .
+          ruff format --check .
+          pip-extra-reqs pip_check_reqs
+          pip-missing-reqs pip_check_reqs
+          pylint pip_check_reqs tests
+          pyroma --min=10 .
+          pyproject-fmt --check .
+          pyright .
           actionlint
 
       - name: "Run tests"
-        run: uv run --no-sync pytest -s -vvv --cov-fail-under 100 --cov=pip_check_reqs/ --cov=tests tests/ --cov-report=xml
+        shell: bash
+        run: |
+          source .venv/bin/activate || source .venv/Scripts/activate
+          pytest -s -vvv --cov-fail-under 100 --cov=pip_check_reqs/ --cov=tests tests/ --cov-report=xml
 
   completion-ci:
     needs: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,9 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
+    env:
+      VENV_PATH: ${{ matrix.os == 'windows-latest' && 'C:/Users/runner/.venv' || '/home/runner/.venv' }}
+
     steps:
       - uses: actions/checkout@v6
 
@@ -31,23 +34,14 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: "Create virtual environment"
-        id: venv
-        shell: bash
-        run: |
-          if [ "${{ matrix.os }}" = "windows-latest" ]; then
-            uv venv C:/Users/runner/.venv
-            echo "activate=source C:/Users/runner/.venv/Scripts/activate" >> "$GITHUB_OUTPUT"
-          else
-            uv venv /home/runner/.venv
-            echo "activate=source /home/runner/.venv/bin/activate" >> "$GITHUB_OUTPUT"
-          fi
+        run: uv venv ${{ env.VENV_PATH }}
 
       - name: "Install dependencies"
         # Use bash to ensure the step fails if any command fails.
         # PowerShell does not fail on intermediate command failures by default.
         shell: bash
         run: |
-          ${{ steps.venv.outputs.activate }}
+          source "$VENV_PATH/bin/activate" || source "$VENV_PATH/Scripts/activate"
           # We want the latest dev requirements, but the lowest install requirements.
           uv pip install --upgrade --editable .[dev]
           uv pip install --resolution=${{ matrix.uv-resolution }} --upgrade --editable .
@@ -57,7 +51,7 @@ jobs:
         # PowerShell does not fail on intermediate command failures by default.
         shell: bash
         run: |
-          ${{ steps.venv.outputs.activate }}
+          source "$VENV_PATH/bin/activate" || source "$VENV_PATH/Scripts/activate"
           mypy .
           ruff check .
           ruff format --check .
@@ -74,7 +68,7 @@ jobs:
         # PowerShell does not fail on intermediate command failures by default.
         shell: bash
         run: |
-          ${{ steps.venv.outputs.activate }}
+          source "$VENV_PATH/bin/activate" || source "$VENV_PATH/Scripts/activate"
           pytest -s -vvv --cov-fail-under 100 --cov=pip_check_reqs/ --cov=tests tests/ --cov-report=xml
 
   completion-ci:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,24 +36,24 @@ jobs:
       - name: "Install dependencies"
         run: |
           # We want the latest dev requirements, but the lowest install requirements.
-          uv pip install --editable .[dev]
-          uv pip install --resolution=${{ matrix.uv-resolution }} --editable .
+          uv pip install --upgrade --editable .[dev]
+          uv pip install --resolution=${{ matrix.uv-resolution }} --upgrade --editable .
 
       - name: "Lint"
         run: |
-          uv run mypy .
-          uv run ruff check .
-          uv run ruff format --check .
-          uv run pip-extra-reqs pip_check_reqs
-          uv run pip-missing-reqs pip_check_reqs
-          uv run pylint pip_check_reqs tests
-          uv run pyroma --min=10 .
-          uv run pyproject-fmt --check .
-          uv run pyright .
+          uv run --no-sync mypy .
+          uv run --no-sync ruff check .
+          uv run --no-sync ruff format --check .
+          uv run --no-sync pip-extra-reqs pip_check_reqs
+          uv run --no-sync pip-missing-reqs pip_check_reqs
+          uv run --no-sync pylint pip_check_reqs tests
+          uv run --no-sync pyroma --min=10 .
+          uv run --no-sync pyproject-fmt --check .
+          uv run --no-sync pyright .
           actionlint
 
       - name: "Run tests"
-        run: uv run pytest -s -vvv --cov-fail-under 100 --cov=pip_check_reqs/ --cov=tests tests/ --cov-report=xml
+        run: uv run --no-sync pytest -s -vvv --cov-fail-under 100 --cov=pip_check_reqs/ --cov=tests tests/ --cov-report=xml
 
   completion-ci:
     needs: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,8 @@ jobs:
         run: |
           uv venv ${{ env.UV_PROJECT_ENVIRONMENT }}
           # We want the latest dev requirements, but the lowest install requirements.
-          uv pip install --upgrade --editable .[dev]
-          uv pip install --resolution=${{ matrix.uv-resolution }} --upgrade --editable .
+          uv pip install --python ${{ env.UV_PROJECT_ENVIRONMENT }} --upgrade --editable .[dev]
+          uv pip install --python ${{ env.UV_PROJECT_ENVIRONMENT }} --resolution=${{ matrix.uv-resolution }} --upgrade --editable .
 
       - name: "Lint"
         # Use bash to ensure the step fails if any command fails.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,6 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
-    env:
-      UV_PROJECT_ENVIRONMENT: .venv
-
     steps:
       - uses: actions/checkout@v6
 
@@ -34,11 +31,21 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: "Create virtual environment"
-        run: uv venv
+        id: venv
+        shell: bash
+        run: |
+          if [ "${{ matrix.os }}" = "windows-latest" ]; then
+            uv venv C:/Users/runner/.venv
+            echo "activate=source C:/Users/runner/.venv/Scripts/activate" >> "$GITHUB_OUTPUT"
+          else
+            uv venv /home/runner/.venv
+            echo "activate=source /home/runner/.venv/bin/activate" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: "Install dependencies"
         shell: bash
         run: |
+          ${{ steps.venv.outputs.activate }}
           # We want the latest dev requirements, but the lowest install requirements.
           uv pip install --upgrade --editable .[dev]
           uv pip install --resolution=${{ matrix.uv-resolution }} --upgrade --editable .
@@ -46,7 +53,7 @@ jobs:
       - name: "Lint"
         shell: bash
         run: |
-          source .venv/bin/activate || source .venv/Scripts/activate
+          ${{ steps.venv.outputs.activate }}
           mypy .
           ruff check .
           ruff format --check .
@@ -61,7 +68,7 @@ jobs:
       - name: "Run tests"
         shell: bash
         run: |
-          source .venv/bin/activate || source .venv/Scripts/activate
+          ${{ steps.venv.outputs.activate }}
           pytest -s -vvv --cov-fail-under 100 --cov=pip_check_reqs/ --cov=tests tests/ --cov-report=xml
 
   completion-ci:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
           uv run --no-sync pyroma --min=10 .
           uv run --no-sync pyproject-fmt --check .
           uv run --no-sync pyright .
-          actionlint
+          uv run --no-sync actionlint
 
       - name: "Run tests"
         run: uv run --no-sync pytest -s -vvv --cov-fail-under 100 --cov=pip_check_reqs/ --cov=tests tests/ --cov-report=xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,8 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     env:
-      VENV_PATH: ${{ matrix.os == 'windows-latest' && 'C:/Users/runner/.venv' || '/home/runner/.venv' }}
+      # Set venv outside project dir so pip-extra-reqs resolves paths correctly
+      UV_PROJECT_ENVIRONMENT: ${{ matrix.os == 'windows-latest' && 'C:/Users/runner/.venv' || '/home/runner/.venv' }}
 
     steps:
       - uses: actions/checkout@v6
@@ -33,15 +34,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: "Create virtual environment"
-        run: uv venv ${{ env.VENV_PATH }}
-
       - name: "Install dependencies"
-        # Use bash to ensure the step fails if any command fails.
-        # PowerShell does not fail on intermediate command failures by default.
-        shell: bash
         run: |
-          source "$VENV_PATH/bin/activate" || source "$VENV_PATH/Scripts/activate"
           # We want the latest dev requirements, but the lowest install requirements.
           uv pip install --upgrade --editable .[dev]
           uv pip install --resolution=${{ matrix.uv-resolution }} --upgrade --editable .
@@ -51,25 +45,19 @@ jobs:
         # PowerShell does not fail on intermediate command failures by default.
         shell: bash
         run: |
-          source "$VENV_PATH/bin/activate" || source "$VENV_PATH/Scripts/activate"
-          mypy .
-          ruff check .
-          ruff format --check .
-          pip-extra-reqs pip_check_reqs
-          pip-missing-reqs pip_check_reqs
-          pylint pip_check_reqs tests
-          pyroma --min=10 .
-          pyproject-fmt --check .
-          pyright .
+          uv run --no-sync mypy .
+          uv run --no-sync ruff check .
+          uv run --no-sync ruff format --check .
+          uv run --no-sync pip-extra-reqs pip_check_reqs
+          uv run --no-sync pip-missing-reqs pip_check_reqs
+          uv run --no-sync pylint pip_check_reqs tests
+          uv run --no-sync pyroma --min=10 .
+          uv run --no-sync pyproject-fmt --check .
+          uv run --no-sync pyright .
           actionlint
 
       - name: "Run tests"
-        # Use bash to ensure the step fails if any command fails.
-        # PowerShell does not fail on intermediate command failures by default.
-        shell: bash
-        run: |
-          source "$VENV_PATH/bin/activate" || source "$VENV_PATH/Scripts/activate"
-          pytest -s -vvv --cov-fail-under 100 --cov=pip_check_reqs/ --cov=tests tests/ --cov-report=xml
+        run: uv run --no-sync pytest -s -vvv --cov-fail-under 100 --cov=pip_check_reqs/ --cov=tests tests/ --cov-report=xml
 
   completion-ci:
     needs: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,11 +30,14 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: "Create virtual environment"
+        run: uv venv
+
       - name: "Install dependencies"
         run: |
           # We want the latest dev requirements, but the lowest install requirements.
-          uv sync --all-extras
-          uv sync --resolution=${{ matrix.uv-resolution }}
+          uv pip install --editable .[dev]
+          uv pip install --resolution=${{ matrix.uv-resolution }} --editable .
 
       - name: "Lint"
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,8 @@ jobs:
           fi
 
       - name: "Install dependencies"
+        # Use bash to ensure the step fails if any command fails.
+        # PowerShell does not fail on intermediate command failures by default.
         shell: bash
         run: |
           ${{ steps.venv.outputs.activate }}
@@ -51,6 +53,8 @@ jobs:
           uv pip install --resolution=${{ matrix.uv-resolution }} --upgrade --editable .
 
       - name: "Lint"
+        # Use bash to ensure the step fails if any command fails.
+        # PowerShell does not fail on intermediate command failures by default.
         shell: bash
         run: |
           ${{ steps.venv.outputs.activate }}
@@ -66,6 +70,8 @@ jobs:
           actionlint
 
       - name: "Run tests"
+        # Use bash to ensure the step fails if any command fails.
+        # PowerShell does not fail on intermediate command failures by default.
         shell: bash
         run: |
           ${{ steps.venv.outputs.activate }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,60 +24,33 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-      - name: "Set up Python"
-        uses: actions/setup-python@v6
-        with:
-          python-version: ${{ matrix.python-version }}
 
       - name: "Install uv"
         uses: astral-sh/setup-uv@v7
-
-      - name: "Create virtual environment"
-        id: venv
-        run: |
-          if [ "${{ matrix.os }}" = "windows-latest" ]; then
-            uv venv C:/Users/runner/.venv
-            echo "activate=source C:/Users/runner/.venv/Scripts/activate" >> "$GITHUB_OUTPUT"
-          else
-            uv venv /home/runner/.venv
-            echo "activate=source /home/runner/.venv/bin/activate" >> "$GITHUB_OUTPUT"
-          fi
-        shell: bash
+        with:
+          python-version: ${{ matrix.python-version }}
 
       - name: "Install dependencies"
-        # Use bash to ensure the step fails if any command fails.
-        # PowerShell does not fail on intermediate command failures by default.
-        shell: bash
         run: |
-          ${{ steps.venv.outputs.activate }}
           # We want the latest dev requirements, but the lowest install requirements.
-          uv pip install --upgrade --editable .[dev]
-          uv pip install --resolution=${{ matrix.uv-resolution }} --upgrade --editable .
+          uv sync --all-extras
+          uv sync --resolution=${{ matrix.uv-resolution }}
 
       - name: "Lint"
-        # Use bash to ensure the step fails if any command fails.
-        # PowerShell does not fail on intermediate command failures by default.
-        shell: bash
         run: |
-          ${{ steps.venv.outputs.activate }}
-          mypy .
-          ruff check .
-          ruff format --check .
-          pip-extra-reqs pip_check_reqs
-          pip-missing-reqs pip_check_reqs
-          pylint pip_check_reqs tests
-          pyroma --min=10 .
-          pyproject-fmt --check .
-          pyright .
+          uv run mypy .
+          uv run ruff check .
+          uv run ruff format --check .
+          uv run pip-extra-reqs pip_check_reqs
+          uv run pip-missing-reqs pip_check_reqs
+          uv run pylint pip_check_reqs tests
+          uv run pyroma --min=10 .
+          uv run pyproject-fmt --check .
+          uv run pyright .
           actionlint
 
       - name: "Run tests"
-        # Use bash to ensure the step fails if any command fails.
-        # PowerShell does not fail on intermediate command failures by default.
-        shell: bash
-        run: |
-          ${{ steps.venv.outputs.activate }}
-          pytest -s -vvv --cov-fail-under 100 --cov=pip_check_reqs/ --cov=tests tests/ --cov-report=xml
+        run: uv run pytest -s -vvv --cov-fail-under 100 --cov=pip_check_reqs/ --cov=tests tests/ --cov-report=xml
 
   completion-ci:
     needs: build


### PR DESCRIPTION
- Remove `setup-python` action - uv handles Python installation via `python-version` input
- Remove manual venv creation - uv manages this automatically
- Use `uv sync` instead of `uv pip install`
- Use `uv run` to execute commands in the managed environment
- Remove bash shell specification (no longer needed without venv activation)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Migrates the CI workflow to rely on `astral-sh/setup-uv` for Python setup and environment management, removing redundant steps and executing tools via `uv`.
> 
> - Defines `UV_PROJECT_ENVIRONMENT` (OS-specific) and uses `uv venv` plus `uv pip install` to create/install into a stable venv outside the project
> - Replaces `setup-python` and manual venv activation with `setup-uv` using `python-version` from the matrix
> - Runs linting and tests via `uv run --no-sync` across all tools (`mypy`, `ruff`, `pytest`, etc.)
> - Keeps the test/lint matrix the same; no application code changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 68720342ec3c76f014ec58a20f7e67edd7e250bd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->