### PR TITLE
Prepare release 2.5.6

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Release History
 ---------------
 
+2.5.6
+
+- Fix path resolution when virtual environment is inside the project directory.
+- Support for Python 3.14.
+
 2.5.5
 
 - Add CHANGELOG back to source distribution.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -13,9 +13,8 @@ Run the following steps, entering a PyPI API token when prompted:
 
    git checkout master && \
    git pull && \
-   pip install --upgrade twine build && \
-   pip install -r requirements.txt && \
+   uv pip install --upgrade twine build && \
    rm -rf build dist && \
    git status # There should be no uncommitted changes.  && \
-   python -m build && \
-   twine upload --username=__token__ -r pypi dist/*
+   uv run python -m build && \
+   uv run twine upload --username=__token__ -r pypi dist/*

--- a/pip_check_reqs/__init__.py
+++ b/pip_check_reqs/__init__.py
@@ -1,3 +1,3 @@
 """Package for finding missing and extra requirements."""
 
-__version__ = "2.5.5"
+__version__ = "2.5.6"


### PR DESCRIPTION
## Changes

- Bump version to 2.5.6
- Update CHANGELOG

## Release notes

- Fix path resolution when virtual environment is inside the project directory.
- Support for Python 3.14.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prepares the 2.5.6 release.
> 
> - Bumps `__version__` to `2.5.6`
> - Updates `CHANGELOG.rst` with notes: fix path resolution when virtualenv is inside the project directory; add Python 3.14 support
> - Updates release steps in `CONTRIBUTING.rst` to use `uv` for building and uploading
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 47702a56ad0f53f091c874733aab6610192983d5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->