### PR TITLE
Enable coverage report.show_missing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,22 +51,17 @@ scripts.pip-missing-reqs = "pip_check_reqs.find_missing_reqs:main"
 packages = [
   "pip_check_reqs",
 ]
-
-[tool.setuptools.dynamic]
-version = { attr = "pip_check_reqs.__version__" }
-readme = { file = "README.rst", content-type = "text/x-rst" }
-dependencies = { file = "requirements.txt" }
-optional-dependencies = { dev = { file = "test-requirements.txt" } }
+dynamic.version = { attr = "pip_check_reqs.__version__" }
+dynamic.readme = { file = "README.rst", content-type = "text/x-rst" }
+dynamic.dependencies = { file = "requirements.txt" }
+dynamic.optional-dependencies = { dev = { file = "test-requirements.txt" } }
 
 [tool.ruff]
-
 target-version = "py39"
-
 line-length = 79
 lint.select = [
   "ALL",
 ]
-
 lint.ignore = [
   # We are missing too many docstrings to quickly fix now.
   "D100",
@@ -83,7 +78,6 @@ lint.ignore = [
   # https://mypy.readthedocs.io/en/stable/type_narrowing.html#type-narrowing-expressions.
   "S101",
 ]
-
 # Do not automatically remove commented out code.
 # We comment out code during development, and with VSCode auto-save, this code
 # is sometimes annoyingly removed.
@@ -92,37 +86,30 @@ lint.unfixable = [
 ]
 
 [tool.pylint]
-
-[tool.pylint.'MASTER']
-
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+"FORMAT".single-line-if-stmt = false
 # Pickle collected data for later comparisons.
-persistent = true
-
+"MASTER".persistent = true
 # Use multiple processes to speed up Pylint.
-jobs = 0
-
+"MASTER".jobs = 0
 # List of plugins (as comma separated values of python modules names) to load,
 # usually to register additional checkers.
-load-plugins = [
-  'pylint.extensions.docparams',
-  'pylint.extensions.no_self_use',
+"MASTER".load-plugins = [
+  "pylint.extensions.docparams",
+  "pylint.extensions.no_self_use",
 ]
-
 # Allow loading of arbitrary C extensions. Extensions are imported into the
 # active Python interpreter and may run arbitrary code.
-unsafe-load-any-extension = false
-
-[tool.pylint.'MESSAGES CONTROL']
-
+"MASTER".unsafe-load-any-extension = false
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option
 # multiple time (only on the command line, not in the configuration file where
 # it should appear only once). See also the "--disable" option for examples.
-enable = [
-  'spelling',
-  'useless-suppression',
+"MESSAGES CONTROL".enable = [
+  "spelling",
+  "useless-suppression",
 ]
-
 # Disable the message, report, category or checker with the given id(s). You
 # can either give multiple identifiers separated by comma (,) or put this
 # option multiple times (only on the command line, not in the configuration
@@ -132,71 +119,53 @@ enable = [
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
-
-disable = [
-  'too-few-public-methods',
-  'too-many-locals',
-  'too-many-arguments',
-  'too-many-instance-attributes',
-  'too-many-return-statements',
-  'too-many-lines',
-  'locally-disabled',
+"MESSAGES CONTROL".disable = [
+  "too-few-public-methods",
+  "too-many-locals",
+  "too-many-arguments",
+  "too-many-instance-attributes",
+  "too-many-return-statements",
+  "too-many-lines",
+  "locally-disabled",
   # Let ruff handle long lines
-  'line-too-long',
+  "line-too-long",
   # Let ruff handle unused imports
-  'unused-import',
+  "unused-import",
   # Let isort deal with sorting
-  'ungrouped-imports',
+  "ungrouped-imports",
   # We don't need everything to be documented because of mypy
-  'missing-type-doc',
-  'missing-return-type-doc',
+  "missing-type-doc",
+  "missing-return-type-doc",
   # Too difficult to please
-  'duplicate-code',
+  "duplicate-code",
   # Let ruff handle imports
-  'wrong-import-order',
+  "wrong-import-order",
   # It would be nice to add this, but it's too much work
   "missing-function-docstring",
   # We will remove this in issue 97
   "deprecated-module",
 ]
-
-[tool.pylint.'FORMAT']
-
-# Allow the body of an if to be on the same line as the test if there is no
-# else.
-single-line-if-stmt = false
-
-[tool.pylint.'SPELLING']
-
 # Spelling dictionary name. Available dictionaries: none. To make it working
 # install python-enchant package.
-spelling-dict = 'en_US'
-
+"SPELLING".spelling-dict = "en_US"
 # A path to a file that contains private dictionary; one word per line.
-spelling-private-dict-file = 'spelling_private_dict.txt'
-
+"SPELLING".spelling-private-dict-file = "spelling_private_dict.txt"
 # Tells whether to store unknown words to indicated private dictionary in
 # --spelling-private-dict-file option instead of raising a message.
-spelling-store-unknown-words = 'no'
+"SPELLING".spelling-store-unknown-words = "no"
 
 [tool.pyproject-fmt]
 keep_full_version = true
 max_supported_python = "3.14"
 
-[tool.coverage.run]
-
-branch = true
-
-[tool.coverage.report]
-
-exclude_also = [
+[tool.coverage]
+report.exclude_also = [
   "if TYPE_CHECKING:",
 ]
+run.branch = true
 
 [tool.mypy]
-
 strict = true
 
 [tool.pyright]
-
 typeCheckingMode = "strict"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,6 +164,7 @@ report.exclude_also = [
 ]
 run.branch = true
 
+report.show_missing = true
 [tool.mypy]
 strict = true
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,7 +2,7 @@ actionlint-py==1.7.10.24
 mypy==1.19.1
 pyenchant==3.3.0
 pylint==3.3.9
-pyproject-fmt==2.8.0
+pyproject-fmt==2.14.2
 pyright==1.1.408
 pyroma==5.0.1
 pytest==8.4.2


### PR DESCRIPTION
Summary: set [tool.coverage] report.show_missing = true in pyproject.toml.\n\nTesting: not run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Configuration-only updates to formatting/tooling and coverage reporting; no runtime code paths are changed.
> 
> **Overview**
> Enables `coverage`’s `report.show_missing = true` and consolidates `coverage` config under a single `[tool.coverage]` table in `pyproject.toml`.
> 
> Also reformats `pyproject.toml` tool config (notably `setuptools.dynamic` and `pylint` sections) to a flatter, `pyproject-fmt`-compatible style, and bumps `pyproject-fmt` in `test-requirements.txt` from `2.8.0` to `2.14.2`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3c21f2c2f9f68cff229fe3db3b3423f81a41a8f4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->