### PR TITLE
Use keyword-only parameters in tests

### DIFF
--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -33,7 +33,7 @@ from pip_check_reqs import __version__, common
         (Path("/ham/spam/__init__.py"), Path("/ham/spam")),
     ],
 )
-def test_package_path(path: Path, result: Path) -> None:
+def test_package_path(*, path: Path, result: Path) -> None:
     assert common.package_path(path=path) == result, path
 
 
@@ -104,6 +104,7 @@ def test_pyfiles_package(tmp_path: Path) -> None:
     ],
 )
 def test_find_imported_modules_simple(
+    *,
     statement: str,
     expected_module_names: set[str],
     tmp_path: Path,

--- a/tests/test_find_extra_reqs.py
+++ b/tests/test_find_extra_reqs.py
@@ -60,6 +60,7 @@ def test_find_extra_reqs(tmp_path: Path) -> None:
 
 
 def test_main_failure(
+    *,
     caplog: pytest.LogCaptureFixture,
     tmp_path: Path,
 ) -> None:
@@ -106,10 +107,10 @@ def test_main_no_spec(capsys: pytest.CaptureFixture[str]) -> None:
     ],
 )
 def test_logging_config(
+    *,
     caplog: pytest.LogCaptureFixture,
     expected_log_levels: set[int],
     tmp_path: Path,
-    *,
     verbose_cfg: bool,
     debug_cfg: bool,
 ) -> None:

--- a/tests/test_find_missing_reqs.py
+++ b/tests/test_find_missing_reqs.py
@@ -65,6 +65,7 @@ def test_find_missing_reqs(tmp_path: Path) -> None:
 
 
 def test_main_failure(
+    *,
     caplog: pytest.LogCaptureFixture,
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- Enforce keyword-only arguments (using `*`) in test functions that accept multiple parameters
- This improves call-site clarity and prevents accidental positional argument errors

## Test plan
- [ ] Verify tests still pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only signature changes with no production code impact; main risk is minor breakage if any test is invoked positionally by plugins/fixtures.
> 
> **Overview**
> Updates several pytest tests to enforce keyword-only parameters by adding `*` to function signatures (e.g., `test_package_path`, `test_find_imported_modules_simple`, and `test_main_failure`/`test_logging_config` cases). This is a signature-only refactor aimed at improving clarity and preventing accidental positional argument ordering issues in tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 14ca7e12db483c674fb076912ee3d11bff9f27c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->