### PR TITLE
Add completion-lint job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
       - name: "Run tests"
         run: uv run --resolution=${{ matrix.uv-resolution }} --extra dev pytest -s -vvv --cov-fail-under 100 --cov=pip_check_reqs/ --cov=tests tests/ --cov-report=xml
 
-  completion-ci:
+  completion-lint:
     needs: build
     runs-on: ubuntu-latest
     if: always() # Run even if one matrix job fails


### PR DESCRIPTION
Rename completion-ci to completion-lint so it shows up in PR checks.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only renames a GitHub Actions job, with no changes to commands executed or build/test behavior.
> 
> **Overview**
> Renames the GitHub Actions workflow job `completion-ci` to `completion-lint` so the completion check shows up under a clearer name in PR status checks.
> 
> No changes to the build matrix, lint/test commands, or the completion job’s failure behavior (`if: always()` + matrix result gate).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0787e1236a99c24c5f092d29d9fcd0bf501cd839. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->