### PR TITLE
Separate lint into lint.yml workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,29 +30,13 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: "Lint"
-        # Use bash to ensure the step fails if any command fails.
-        # PowerShell does not fail on intermediate command failures by default.
-        shell: bash
-        run: |
-          uv run --resolution=${{ matrix.uv-resolution }} --extra dev mypy .
-          uv run --resolution=${{ matrix.uv-resolution }} --extra dev ruff check .
-          uv run --resolution=${{ matrix.uv-resolution }} --extra dev ruff format --check .
-          uv run --resolution=${{ matrix.uv-resolution }} --extra dev pip-extra-reqs pip_check_reqs
-          uv run --resolution=${{ matrix.uv-resolution }} --extra dev pip-missing-reqs pip_check_reqs
-          uv run --resolution=${{ matrix.uv-resolution }} --extra dev pylint pip_check_reqs tests
-          uv run --resolution=${{ matrix.uv-resolution }} --extra dev pyroma --min=10 .
-          uv run --resolution=${{ matrix.uv-resolution }} --extra dev pyproject-fmt --check .
-          uv run --resolution=${{ matrix.uv-resolution }} --extra dev pyright .
-          uv run --resolution=${{ matrix.uv-resolution }} --extra dev actionlint
-
       - name: "Run tests"
         run: uv run --resolution=${{ matrix.uv-resolution }} --extra dev pytest -s -vvv --cov-fail-under 100 --cov=pip_check_reqs/ --cov=tests tests/ --cov-report=xml
 
   completion-ci:
     needs: build
     runs-on: ubuntu-latest
-    if: always() # Run even if one matrix job fails
+    if: always()
     steps:
       - name: Check matrix job status
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,62 @@
+---
+name: Lint
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    # Run at 1:00 every day
+    - cron: "0 1 * * *"
+  workflow_dispatch: {}
+
+permissions: {}
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        uv-resolution: ["highest", "lowest-direct"]
+        # The minimum version should be represented in pyproject.toml.
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        os: [ubuntu-latest, windows-latest]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: "Install uv"
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: "Lint"
+        # Use bash to ensure the step fails if any command fails.
+        # PowerShell does not fail on intermediate command failures by default.
+        shell: bash
+        run: |
+          uv run --resolution=${{ matrix.uv-resolution }} --extra dev mypy .
+          uv run --resolution=${{ matrix.uv-resolution }} --extra dev ruff check .
+          uv run --resolution=${{ matrix.uv-resolution }} --extra dev ruff format --check .
+          uv run --resolution=${{ matrix.uv-resolution }} --extra dev pip-extra-reqs pip_check_reqs
+          uv run --resolution=${{ matrix.uv-resolution }} --extra dev pip-missing-reqs pip_check_reqs
+          uv run --resolution=${{ matrix.uv-resolution }} --extra dev pylint pip_check_reqs tests
+          uv run --resolution=${{ matrix.uv-resolution }} --extra dev pyroma --min=10 .
+          uv run --resolution=${{ matrix.uv-resolution }} --extra dev pyproject-fmt --check .
+          uv run --resolution=${{ matrix.uv-resolution }} --extra dev pyright .
+          uv run --resolution=${{ matrix.uv-resolution }} --extra dev actionlint
+
+  completion-lint:
+    needs: build
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Check matrix job status
+        run: |
+          if ! ${{ needs.build.result == 'success' }}; then
+            echo "One or more matrix jobs failed"
+            exit 1
+          fi


### PR DESCRIPTION
Extract lint into a separate lint.yml workflow with completion-lint, matching the pattern used in wiremock-mock and other repos.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since this only restructures GitHub Actions workflows, but it could change when/where lint runs and affect required status checks.
> 
> **Overview**
> **Splits CI responsibilities:** removes the `Lint` step from `.github/workflows/ci.yml` so the `CI` workflow only runs tests.
> 
> Adds a new `.github/workflows/lint.yml` workflow that runs the existing lint toolchain (mypy/ruff/pylint/pyright/etc.) across the same OS/Python/`uv` resolution matrix and includes a `completion-lint` job to fail the workflow if any matrix entry fails.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 966b1d1e4d6f0df256dfc5ac6215d0ac4f675190. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->