### PR TITLE
Remove unused dependabot/fetch-metadata step

### DIFF
--- a/.github/workflows/dependabot-merge.yml
+++ b/.github/workflows/dependabot-merge.yml
@@ -12,11 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
     steps:
-      - name: Dependabot metadata
-        id: metadata
-        uses: dependabot/fetch-metadata@v2
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Enable auto-merge for Dependabot PRs
         run: gh pr merge --auto --merge "$PR_URL"
         env:


### PR DESCRIPTION
The fetch-metadata step outputs were never used. Removing the unnecessary step.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that removes an unused GitHub Action step without altering merge permissions or behavior.
> 
> **Overview**
> Simplifies the `Dependabot auto-merge` GitHub Actions workflow by removing the unused `dependabot/fetch-metadata@v2` step.
> 
> The job now only enables `gh pr merge --auto --merge` for PRs opened by `dependabot[bot]`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d3c14aa5ee0766fa41c644747f8152ab52f48fb1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->