### PR TITLE
fix: use pull_request.user.login instead of github.actor for bot check

### DIFF
--- a/.github/workflows/dependabot-merge.yml
+++ b/.github/workflows/dependabot-merge.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   dependabot:
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]'
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     steps:
       - name: Enable auto-merge for Dependabot PRs
         run: gh pr merge --auto --merge "$PR_URL"


### PR DESCRIPTION
Fixes adamtheturtle/literalizer#146

The github.actor check is unreliable - it reflects who triggered the workflow, not who opened the PR. Use github.event.pull_request.user.login instead.

Flagged by zizmor bot-conditions audit.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk YAML change that only affects when the Dependabot auto-merge job runs; main risk is unintentionally skipping or enabling auto-merge if the condition is mis-specified.
> 
> **Overview**
> Updates the `Dependabot auto-merge` GitHub Actions workflow to determine bot PRs via `github.event.pull_request.user.login` instead of `github.actor`, so the auto-merge job only runs when the PR was opened by Dependabot (not merely triggered by a Dependabot-related event).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8e1aab3c978205e47f109ab3e3027afca7e73f8e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->