### PR TITLE
Add kw_only to FoundModule dataclass

### DIFF
--- a/pip_check_reqs/common.py
+++ b/pip_check_reqs/common.py
@@ -50,7 +50,7 @@ def get_packages_info() -> list[_PackageInfo]:
     return list(search_packages_info(query=all_pkgs))
 
 
-@dataclass
+@dataclass(kw_only=True)
 class FoundModule:
     """A module with uses in the source."""
 


### PR DESCRIPTION
Adds `kw_only=True` to `FoundModule`. The import visitor and tests already construct instances with keywords.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only enforces keyword-only construction for `FoundModule` and should only impact callers that pass positional args.
> 
> **Overview**
> **Enforces keyword-only initialization** for the `FoundModule` dataclass by adding `kw_only=True`, preventing positional-argument construction.
> 
> This is a small API-surface tightening that aligns with existing keyword-based instantiation and helps avoid argument-order mistakes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f21a293b352e133d01fe48f6b184879ff35ea95. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->