### PR TITLE
[codex] Make useless Pylint suppressions fail lint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,11 @@ persistent = true
 # Use multiple processes to speed up Pylint.
 jobs = 0
 
+# Return non-zero exit code if useless-suppression is emitted.
+fail-on = [
+  'useless-suppression',
+]
+
 # List of plugins (as comma separated values of python modules names) to load,
 # usually to register additional checkers.
 load-plugins = [


### PR DESCRIPTION
## Summary

- Configure Pylint to fail when `useless-suppression` is emitted.
- Keep existing useless-suppression enablement and project-specific Pylint settings intact.

## Validation

- Parsed `pyproject.toml` with `tomllib`.
- Ran `pylint --rcfile pyproject.toml --list-msgs-enabled`.
- Ran repository commit hooks for the changed file.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: config-only change that just makes linting stricter and may cause CI failures where `# pylint: disable` directives are no longer needed.
> 
> **Overview**
> Updates `pyproject.toml` Pylint configuration to **fail the lint run** when `useless-suppression` is reported (via `fail-on = ['useless-suppression']`). This turns redundant `pylint` suppression comments into a hard failure to keep suppressions from accumulating.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcd57ac4b128f6cc5c0c788e9c237ca61fb40b30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->