### PR TITLE
Pin pip to previous release

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 packaging >= 26.2
-pip >= 26.0.1, < 26.1.2; python_version < "3.10"
-pip >= 26.1.2; python_version >= "3.10"
+pip == 26.0.1; python_version < "3.10"
+pip == 26.1.2; python_version >= "3.10"


### PR DESCRIPTION
Pins pip to 26.1.2, the release immediately before 26.2, so newer Python environments use a stable known version instead of automatically resolving the latest release.

Python 3.9 remains pinned to 26.0.1, the latest compatible pip release for that interpreter.

Validated with dependency resolution for Python 3.9 and 3.10 and with the full test suite (`60 passed`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only change with no application code; risk is limited to which pip version environments install.
> 
> **Overview**
> **Pins `pip` in `requirements.txt`** from minimum-version constraints (`>=`) to **exact pins (`==`)**, so installs no longer float to newer pip releases automatically.
> 
> Python **&lt; 3.10** stays on **`pip == 26.0.1`**; **3.10+** is pinned to **`pip == 26.1.2`** (the release before 26.2), matching the intent to avoid picking up the latest pip by default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a82f110e4410a57d3d02ee8a39fa57fa5311e22b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->