### PR TITLE
Extract release process into a script

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -4,17 +4,11 @@ Contributing
 Release process
 ---------------
 
-* Update the CHANGELOG on the master branch
+* Update the CHANGELOG on the master branch.
 * Update ``__version__`` in ``pip_check_reqs/__init__.py`` on the master branch.
 
-Run the following steps, entering a PyPI API token when prompted:
+Run the release script, entering a PyPI API token when prompted:
 
 .. code:: sh
 
-   git checkout master && \
-   git pull && \
-   uv pip install --upgrade twine build && \
-   rm -rf build dist && \
-   git status # There should be no uncommitted changes.  && \
-   uv run python -m build && \
-   uv run twine upload --username=__token__ -r pypi dist/*
+   ./release.sh

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+git checkout master
+git pull
+uv pip install --upgrade twine build
+rm -rf build dist
+
+if [[ -n "$(git status --porcelain)" ]]; then
+    echo "The working tree must be clean before creating a release." >&2
+    exit 1
+fi
+
+uv run python -m build
+uv run twine upload --username=__token__ -r pypi dist/*


### PR DESCRIPTION
Extract the executable release steps from `CONTRIBUTING.rst` into an executable `release.sh` script, leaving the human version and changelog checklist in the documentation.

The script preserves the existing build and PyPI upload workflow while enforcing that the working tree is clean before building, reducing the risk of publishing uncommitted content.

This gives maintainers one repeatable command for releases instead of a copied command chain.

Validated with `bash -n release.sh`, `shellcheck release.sh`, and `git diff --check`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and maintainer-only release automation; no application runtime or user-facing behavior changes.
> 
> **Overview**
> Release publishing steps move from a long copy-paste block in **CONTRIBUTING.rst** into a new **`release.sh`** script; the doc still lists the manual checklist (CHANGELOG, version bump) and tells maintainers to run **`./release.sh`**.
> 
> The script keeps the same flow (checkout master, pull, install build tools, clean artifacts, build, twine upload) and adds **`set -euo pipefail`** plus a **clean working tree** check before building so releases cannot ship with uncommitted files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85018ff8d95763c81790e0a88b2cc496b5620e96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->