### PR TITLE
Ignore uv virtual environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__/
 # Distribution / packaging
 .Python
 env/
+.venv/
 bin/
 build/
 develop-eggs/


### PR DESCRIPTION
Adds `.venv/` to the repository ignore rules so the release script's clean-tree gate does not reject a standard local uv environment.
The gate remains strict for other untracked and modified files, preserving protection against unintended release contents.
This addresses the unresolved review feedback on #575 after that PR was merged.
Validated with `git check-ignore`, `bash -n release.sh`, `shellcheck release.sh`, and `git diff --check`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only updates ignore rules; no runtime, auth, or release logic changes.
> 
> **Overview**
> Adds **`.venv/`** to `.gitignore` so a local **uv** virtual environment is not treated as untracked noise.
> 
> This keeps **`release.sh`**’s **clean working tree** check (`git status --porcelain`) from blocking releases when developers use the usual uv layout, without relaxing the gate for other untracked or modified files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ccb9d9b98bf2fd38b4a0f63a39959105d60b40b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->