### PR TITLE
Tag releases in Git

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -12,5 +12,17 @@ if [[ -n "$(git status --porcelain)" ]]; then
     exit 1
 fi
 
+version="$(
+    uv run python -c \
+        "from pip_check_reqs import __version__; print(__version__)"
+)"
+
+if git rev-parse --verify --quiet "refs/tags/${version}" > /dev/null; then
+    echo "The tag ${version} already exists." >&2
+    exit 1
+fi
+
 uv run python -m build
 uv run twine upload --username=__token__ -r pypi dist/*
+git tag --annotate "${version}" --message "Release ${version}"
+git push origin "${version}"


### PR DESCRIPTION
Updates the release script to derive the package version and reject an existing version tag before publishing. After a successful PyPI upload, it creates an annotated version tag and pushes it to `origin`, making released versions traceable to their commits. Closes #571.

Validation: `bash -n release.sh`, `shellcheck release.sh`, the full test suite with 100% coverage, and the repository lint checks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to the maintainer release script; no runtime package or user-facing behavior is affected.
> 
> **Overview**
> **`release.sh`** now ties each PyPI release to a Git tag on the commit that was published.
> 
> Before building or uploading, the script reads **`pip_check_reqs.__version__`** and **aborts** if a tag with that name already exists, so the same version cannot be released twice by mistake. After a successful **`twine upload`**, it creates an **annotated tag** for that version and **pushes only the tag** to `origin` (not a branch push).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 404314836a54f79c858437aca0d5be8b5582e663. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->