### PR TITLE
Prepare release 3.0.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Release History
 ---------------
 
+3.0.0
+
+- Drop support for Python 3.9. Python 3.10 or later is now required.
+- Require pip 26.2 or later.
+- Require packaging 26.2 or later.
+
 2.5.6
 
 - Fix path resolution when virtual environment is inside the project directory.

--- a/pip_check_reqs/__init__.py
+++ b/pip_check_reqs/__init__.py
@@ -1,3 +1,3 @@
 """Package for finding missing and extra requirements."""
 
-__version__ = "2.5.6"
+__version__ = "3.0.0"


### PR DESCRIPTION
Prepares pip-check-reqs 3.0.0 by bumping the package version and documenting the breaking dependency and support-floor changes.

This release drops Python 3.9 and requires Python 3.10+, pip 26.2+, and packaging 26.2+.

Validated with 60 tests at 100% coverage, the full lint and type-check suite, package builds, and `twine check`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-metadata only (version string and changelog); no runtime or logic changes in this diff.
> 
> **Overview**
> **Release 3.0.0** bumps `__version__` in `pip_check_reqs/__init__.py` from `2.5.6` to `3.0.0` and adds a **3.0.0** section to `CHANGELOG.rst`.
> 
> The changelog documents breaking support floors for this major: **Python 3.9 is dropped** (3.10+ required), plus minimum **pip 26.2** and **packaging 26.2**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4c5e964e14513d6739698afec8ecbc81bcb9966. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->