### PR TITLE
Handle missing CLI input files

### DIFF
--- a/pip_check_reqs/common.py
+++ b/pip_check_reqs/common.py
@@ -27,7 +27,9 @@ from pip._internal.req.req_file import ParsedRequirement, parse_requirements
 from . import __version__
 
 if TYPE_CHECKING:
+    import argparse
     from collections.abc import Callable, Generator, Iterable
+    from typing import NoReturn
 
 log = logging.getLogger(__name__)
 
@@ -153,6 +155,10 @@ class _ImportVisitor(ast.NodeVisitor):
 
 
 def pyfiles(root: Path) -> Generator[Path, None, None]:
+    if not root.exists():
+        msg = f"source path not found: {root}"
+        raise FileNotFoundError(msg)
+
     if root.is_file():
         if root.suffix == ".py":
             yield root.absolute()
@@ -162,6 +168,31 @@ def pyfiles(root: Path) -> Generator[Path, None, None]:
     else:
         for item in root.rglob("*.py"):
             yield item.absolute()
+
+
+def validate_requirements_file(*, path: Path) -> None:
+    if not path.is_file():
+        msg = f"requirements file not found: {path}"
+        raise FileNotFoundError(msg)
+
+
+def report_input_error(
+    *,
+    parser: argparse.ArgumentParser,
+    debug: bool,
+    error: OSError | ValueError,
+) -> NoReturn:
+    if debug:
+        raise error
+    parser.error(str(error))
+
+
+def log_level(*, debug: bool, verbose: bool) -> int:
+    if debug:
+        return logging.DEBUG
+    if verbose:
+        return logging.INFO
+    return logging.WARNING
 
 
 def find_imported_modules(

--- a/pip_check_reqs/find_extra_reqs.py
+++ b/pip_check_reqs/find_extra_reqs.py
@@ -181,25 +181,33 @@ def main(arguments: list[str] | None = None) -> None:
     ignore_reqs = common.ignorer(ignore_cfg=parse_result.ignore_reqs)
 
     logging.basicConfig(format="%(message)s")
-    if parse_result.debug:
-        level = logging.DEBUG
-    elif parse_result.verbose:
-        level = logging.INFO
-    else:
-        level = logging.WARNING
+    level = common.log_level(
+        debug=parse_result.debug,
+        verbose=parse_result.verbose,
+    )
     log.setLevel(level)
     common.log.setLevel(level)
 
     log.info(common.version_info())
 
-    extras = find_extra_reqs(
-        requirements_filename=parse_result.requirements_filename,
-        paths=parse_result.paths,
-        ignore_files_function=ignore_files,
-        ignore_modules_function=ignore_mods,
-        ignore_requirements_function=ignore_reqs,
-        skip_incompatible=parse_result.skip_incompatible,
-    )
+    try:
+        common.validate_requirements_file(
+            path=parse_result.requirements_filename,
+        )
+        extras = find_extra_reqs(
+            requirements_filename=parse_result.requirements_filename,
+            paths=parse_result.paths,
+            ignore_files_function=ignore_files,
+            ignore_modules_function=ignore_mods,
+            ignore_requirements_function=ignore_reqs,
+            skip_incompatible=parse_result.skip_incompatible,
+        )
+    except (OSError, ValueError) as error:
+        common.report_input_error(
+            parser=parser,
+            debug=parse_result.debug,
+            error=error,
+        )
 
     if extras:
         log.warning("Extra requirements:")

--- a/pip_check_reqs/find_missing_reqs.py
+++ b/pip_check_reqs/find_missing_reqs.py
@@ -164,23 +164,31 @@ def main(arguments: list[str] | None = None) -> None:
     ignore_mods = common.ignorer(ignore_cfg=parse_result.ignore_mods)
 
     logging.basicConfig(format="%(message)s")
-    if parse_result.debug:
-        level = logging.DEBUG
-    elif parse_result.verbose:
-        level = logging.INFO
-    else:
-        level = logging.WARNING
+    level = common.log_level(
+        debug=parse_result.debug,
+        verbose=parse_result.verbose,
+    )
     log.setLevel(level)
     common.log.setLevel(level)
 
     log.info(common.version_info())
 
-    missing = find_missing_reqs(
-        requirements_filename=parse_result.requirements_filename,
-        paths=parse_result.paths,
-        ignore_files_function=ignore_files,
-        ignore_modules_function=ignore_mods,
-    )
+    try:
+        common.validate_requirements_file(
+            path=parse_result.requirements_filename,
+        )
+        missing = find_missing_reqs(
+            requirements_filename=parse_result.requirements_filename,
+            paths=parse_result.paths,
+            ignore_files_function=ignore_files,
+            ignore_modules_function=ignore_mods,
+        )
+    except (OSError, ValueError) as error:
+        common.report_input_error(
+            parser=parser,
+            debug=parse_result.debug,
+            error=error,
+        )
 
     if missing:
         log.warning("Missing requirements:")

--- a/tests/test_find_extra_reqs.py
+++ b/tests/test_find_extra_reqs.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 import textwrap
 from typing import TYPE_CHECKING
 
@@ -95,6 +96,73 @@ def test_main_no_spec(capsys: pytest.CaptureFixture[str]) -> None:
     assert excinfo.value.code == expected_code
     err = capsys.readouterr().err
     assert err.endswith("error: no source files or directories specified\n")
+
+
+def test_main_missing_requirements_file(
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    requirements_file = tmp_path / "missing-requirements.txt"
+
+    with pytest.raises(SystemExit) as excinfo:
+        find_extra_reqs.main(
+            arguments=[
+                "--requirements",
+                str(requirements_file),
+                str(source_dir),
+            ],
+        )
+
+    expected_code = 2
+    assert excinfo.value.code == expected_code
+    err = capsys.readouterr().err
+    assert err.endswith(
+        f"error: requirements file not found: {requirements_file}\n",
+    )
+
+
+def test_main_missing_source_path(
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    requirements_file = tmp_path / "requirements.txt"
+    requirements_file.touch()
+    source_dir = tmp_path / "missing-source"
+
+    with pytest.raises(SystemExit) as excinfo:
+        find_extra_reqs.main(
+            arguments=[
+                "--requirements",
+                str(requirements_file),
+                str(source_dir),
+            ],
+        )
+
+    expected_code = 2
+    assert excinfo.value.code == expected_code
+    err = capsys.readouterr().err
+    assert err.endswith(f"error: source path not found: {source_dir}\n")
+
+
+def test_main_debug_reraises_input_error(tmp_path: Path) -> None:
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    requirements_file = tmp_path / "missing-requirements.txt"
+
+    with pytest.raises(
+        FileNotFoundError,
+        match=re.escape(f"requirements file not found: {requirements_file}"),
+    ):
+        find_extra_reqs.main(
+            arguments=[
+                "--debug",
+                "--requirements",
+                str(requirements_file),
+                str(source_dir),
+            ],
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_find_missing_reqs.py
+++ b/tests/test_find_missing_reqs.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 import textwrap
 from pathlib import Path
 
@@ -108,6 +109,73 @@ def test_main_no_spec(capsys: pytest.CaptureFixture[str]) -> None:
     assert excinfo.value.code == expected_code
     err = capsys.readouterr().err
     assert err.endswith("error: no source files or directories specified\n")
+
+
+def test_main_missing_requirements_file(
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    requirements_file = tmp_path / "missing-requirements.txt"
+
+    with pytest.raises(SystemExit) as excinfo:
+        find_missing_reqs.main(
+            arguments=[
+                "--requirements",
+                str(requirements_file),
+                str(source_dir),
+            ],
+        )
+
+    expected_code = 2
+    assert excinfo.value.code == expected_code
+    err = capsys.readouterr().err
+    assert err.endswith(
+        f"error: requirements file not found: {requirements_file}\n",
+    )
+
+
+def test_main_missing_source_path(
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    requirements_file = tmp_path / "requirements.txt"
+    requirements_file.touch()
+    source_dir = tmp_path / "missing-source"
+
+    with pytest.raises(SystemExit) as excinfo:
+        find_missing_reqs.main(
+            arguments=[
+                "--requirements",
+                str(requirements_file),
+                str(source_dir),
+            ],
+        )
+
+    expected_code = 2
+    assert excinfo.value.code == expected_code
+    err = capsys.readouterr().err
+    assert err.endswith(f"error: source path not found: {source_dir}\n")
+
+
+def test_main_debug_reraises_input_error(tmp_path: Path) -> None:
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    requirements_file = tmp_path / "missing-requirements.txt"
+
+    with pytest.raises(
+        FileNotFoundError,
+        match=re.escape(f"requirements file not found: {requirements_file}"),
+    ):
+        find_missing_reqs.main(
+            arguments=[
+                "--debug",
+                "--requirements",
+                str(requirements_file),
+                str(source_dir),
+            ],
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #48.

Missing requirements files currently leak pip's internal exception, while missing source paths can be silently ignored.
This validates both inputs and reports concise argparse errors in `pip-missing-reqs` and `pip-extra-reqs`, while retaining tracebacks when `--debug` is enabled.
Regression tests cover both commands; local validation passed with 100% coverage, Ruff, Pylint, mypy, Pyright, and formatting checks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI input validation and error-handling only; no changes to dependency analysis or pip integration beyond earlier failure on bad paths.
> 
> **Overview**
> **`pip-missing-reqs` and `pip-extra-reqs` now validate CLI inputs before scanning**, so missing requirements files no longer surface pip’s internal errors and missing source paths are no longer treated as empty trees.
> 
> Shared helpers in `common` check that the requirements file and each source path exist (`validate_requirements_file`, `pyfiles` existence check), map `OSError`/`ValueError` to concise `argparse` messages via `report_input_error`, and centralize log level selection in `log_level`. With **`--debug`**, those input errors are re-raised for full tracebacks.
> 
> Regression tests cover both commands for missing requirements, missing source paths, and debug re-raise behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cc776f5fa1597b3069a46bc8e68e8605c19d4a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->