### PR TITLE
Support multiple requirements files in pip-missing-reqs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,6 +37,12 @@ Basic usage, running in your project directory::
 This will find all imports in the code in "sample" and check that the
 packages those modules belong to are in the requirements.txt file.
 
+If dependencies are split across multiple files, repeat ``--requirements-file``
+to check them together::
+
+    pip-missing-reqs --requirements-file=requirements.txt \
+        --requirements-file=test-requirements.txt sample
+
 Additionally it is possible to check that there are no dependencies in
 requirements.txt that are then unused in the project::
 

--- a/pip_check_reqs/find_missing_reqs.py
+++ b/pip_check_reqs/find_missing_reqs.py
@@ -27,6 +27,7 @@ def find_missing_reqs(
     paths: Iterable[Path],
     ignore_files_function: Callable[[str], bool],
     ignore_modules_function: Callable[[str], bool],
+    additional_requirements_filenames: Iterable[Path] = (),
 ) -> list[tuple[NormalizedName, list[common.FoundModule]]]:
     # 1. find files used by imports in the code (as best we can without
     #    executing)
@@ -84,17 +85,21 @@ def find_missing_reqs(
 
     # 4. compare with requirements
     explicit: set[NormalizedName] = set()
-    for requirement in parse_requirements(
-        str(requirements_filename),
-        session=PipSession(),
-    ):
-        requirement_name = install_req_from_line(
-            requirement.requirement,
-        ).name
+    for filename in [
+        requirements_filename,
+        *additional_requirements_filenames,
+    ]:
+        for requirement in parse_requirements(
+            str(filename),
+            session=PipSession(),
+        ):
+            requirement_name = install_req_from_line(
+                requirement.requirement,
+            ).name
 
-        assert isinstance(requirement_name, str)
-        log.debug("found requirement: %s", requirement_name)
-        explicit.add(canonicalize_name(requirement_name))
+            assert isinstance(requirement_name, str)
+            log.debug("found requirement: %s", requirement_name)
+            explicit.add(canonicalize_name(requirement_name))
 
     return [(name, used[name]) for name in used if name not in explicit]
 
@@ -104,11 +109,14 @@ def main(arguments: list[str] | None = None) -> None:
     parser.add_argument("paths", type=Path, nargs="*")
     parser.add_argument(
         "--requirements-file",
-        dest="requirements_filename",
+        dest="requirements_filenames",
         metavar="PATH",
         type=Path,
-        default="requirements.txt",
-        help='path to the requirements file (defaults to "requirements.txt")',
+        action="append",
+        help=(
+            "path to a requirements file; may be repeated "
+            '(defaults to "requirements.txt")'
+        ),
     )
     parser.add_argument(
         "-f",
@@ -160,6 +168,9 @@ def main(arguments: list[str] | None = None) -> None:
     if not parse_result.paths:
         parser.error("no source files or directories specified")
 
+    requirements_filenames = parse_result.requirements_filenames or [
+        Path("requirements.txt"),
+    ]
     ignore_files = common.ignorer(ignore_cfg=parse_result.ignore_files)
     ignore_mods = common.ignorer(ignore_cfg=parse_result.ignore_mods)
 
@@ -174,14 +185,14 @@ def main(arguments: list[str] | None = None) -> None:
     log.info(common.version_info())
 
     try:
-        common.validate_requirements_file(
-            path=parse_result.requirements_filename,
-        )
+        for requirements_filename in requirements_filenames:
+            common.validate_requirements_file(path=requirements_filename)
         missing = find_missing_reqs(
-            requirements_filename=parse_result.requirements_filename,
+            requirements_filename=requirements_filenames[0],
             paths=parse_result.paths,
             ignore_files_function=ignore_files,
             ignore_modules_function=ignore_mods,
+            additional_requirements_filenames=requirements_filenames[1:],
         )
     except (OSError, ValueError) as error:
         common.report_input_error(

--- a/tests/test_find_missing_reqs.py
+++ b/tests/test_find_missing_reqs.py
@@ -65,6 +65,33 @@ def test_find_missing_reqs(tmp_path: Path) -> None:
     assert result == expected_result
 
 
+def test_main_multiple_requirements_files(
+    *,
+    caplog: pytest.LogCaptureFixture,
+    tmp_path: Path,
+) -> None:
+    first_requirements_file = tmp_path / "requirements.txt"
+    first_requirements_file.write_text("pip\n")
+    second_requirements_file = tmp_path / "test-requirements.txt"
+    second_requirements_file.write_text("pytest\n")
+
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    (source_dir / "source.py").write_text("import pip\nimport pytest\n")
+
+    find_missing_reqs.main(
+        arguments=[
+            "--requirements-file",
+            str(first_requirements_file),
+            "--requirements-file",
+            str(second_requirements_file),
+            str(source_dir),
+        ],
+    )
+
+    assert not caplog.records
+
+
 def test_main_failure(
     *,
     caplog: pytest.LogCaptureFixture,


### PR DESCRIPTION
Allow `pip-missing-reqs` users to repeat `--requirements-file` so dependencies split across files are checked as one combined set. The implementation preserves the existing single-file API while validating and parsing any additional files, adds a CLI regression test, and documents the new usage.

This resolves the behavior where only one requirements file could be considered at a time. Closes #127.

Validation: 67 tests passed with 100% coverage; mypy, Ruff, Pylint, Pyright, Pyroma, formatting, and actionlint passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped CLI and parsing change for missing-req detection only; default single-file behavior is preserved and covered by a new regression test.
> 
> **Overview**
> **`pip-missing-reqs` can now treat several requirements files as one combined dependency set** by repeating `--requirements-file`. When the flag is omitted, behavior still defaults to a single `requirements.txt`.
> 
> The CLI collects paths with `action="append"` and validates every file before analysis. **`find_missing_reqs`** unions requirements parsed from the first file plus any additional filenames, so imports satisfied in a secondary file (for example test requirements) are no longer reported as missing.
> 
> README documents the repeated-flag usage, and a test covers two files with `pip` and `pytest` imports reporting no warnings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6647fd28a0a4cb1935c98a89d5183cfe27846cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->