### PR TITLE
Avoid false positives for imports from missing submodules

### DIFF
--- a/pip_check_reqs/common.py
+++ b/pip_check_reqs/common.py
@@ -93,11 +93,27 @@ class _ImportVisitor(ast.NodeVisitor):
         if node.module == "__future__":
             # not an actual module
             return
+        if node.module is None or node.level != 0:
+            # relative import
+            return
+        if not self._module_exists(modname=node.module):
+            return
         for alias in node.names:
-            if node.module is None or node.level != 0:
-                # relative import
-                continue
             self._add_module(node.module + "." + alias.name, node.lineno)
+
+    @staticmethod
+    def _module_exists(*, modname: str) -> bool:
+        modname_parts_progress: list[str] = []
+        for modname_part in modname.split("."):
+            name = ".".join([*modname_parts_progress, modname_part])
+            try:
+                module_spec = find_spec(name=name)
+            except (ModuleNotFoundError, ValueError):
+                return False
+            if module_spec is None:
+                return False
+            modname_parts_progress.append(modname_part)
+        return True
 
     def _add_module(self, modname: str, lineno: int) -> None:
         if self._ignore_modules_function(modname):

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -242,6 +242,33 @@ def test_find_imported_modules_period(tmp_path: Path) -> None:
 
 
 @pytest.mark.parametrize(
+    "parent_name",
+    [
+        "pytest",
+        "pprint",
+    ],
+)
+def test_find_imported_modules_missing_from_submodule(
+    parent_name: str,
+    tmp_path: Path,
+) -> None:
+    """A missing sub-module is not attributed to its installed parent."""
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    (source_dir / "example.py").write_text(
+        f"from {parent_name}.missing import attribute",
+    )
+
+    result = common.find_imported_modules(
+        paths=[source_dir],
+        ignore_files_function=common.ignorer(ignore_cfg=[]),
+        ignore_modules_function=common.ignorer(ignore_cfg=[]),
+    )
+
+    assert not result
+
+
+@pytest.mark.parametrize(
     ("ignore_ham", "ignore_hashlib", "expect", "locs"),
     [
         (


### PR DESCRIPTION
Fixes #397.

Validate the complete source module in `from ... import ...` statements before attributing the import to an installed parent distribution, preventing unrelated namespace packages from being reported as missing requirements. Add regression coverage for missing children of both packages and modules.

Tests: 69 tests pass with 100% coverage; Ruff, MyPy, Pyright, and Pylint pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to AST import scanning with added regression tests; no auth, packaging, or requirements-file logic is touched.
> 
> **Overview**
> **`from parent.missing import …`** is no longer treated as a use of an installed **`parent`** when **`parent.missing`** does not resolve. **`visit_ImportFrom`** now bails out early (after the existing relative/`__future__` checks) unless a new **`_module_exists`** helper can resolve every segment of **`node.module`** via **`find_spec`**.
> 
> Regression tests cover missing children under both a package (**`pytest`**) and a module (**`pprint`**), expecting no imported modules to be recorded.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1bf5fd8a25974f446293e48d061b34c4ea92483. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->