### PR TITLE
Lint prose with Vale to ban em dashes

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -49,14 +49,32 @@ jobs:
           uv run --resolution=${{ matrix.uv-resolution }} --extra dev pyright .
           uv run --resolution=${{ matrix.uv-resolution }} --extra dev actionlint
 
+  prose:
+    name: Vale
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: "Install uv"
+        uses: astral-sh/setup-uv@v9.0.0
+
+      # ClearProse bans em dashes.  The style package is pinned in
+      # ``.vale.ini`` and ``vale sync`` downloads it into the gitignored
+      # ``styles`` directory.  Vale needs ``rst2html`` from Docutils on the
+      # ``PATH`` to parse reStructuredText.
+      - name: "Lint prose"
+        run: |
+          uvx --with docutils vale@3.13.0.0 sync
+          git ls-files '*.rst' '*.md' | xargs --no-run-if-empty uvx --with docutils vale@3.13.0.0
+
   completion-lint:
-    needs: build
+    needs: [build, prose]
     runs-on: ubuntu-latest
     if: always()
     steps:
       - name: Check matrix job status
         run: |
-          if ! ${{ needs.build.result == 'success' }}; then
+          if ! ${{ needs.build.result == 'success' && needs.prose.result == 'success' }}; then
             echo "One or more matrix jobs failed"
             exit 1
           fi

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ coverage.xml
 docs/_build/
 
 uv.lock
+
+# Vale styles downloaded by ``vale sync``
+styles/

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,0 +1,7 @@
+StylesPath = styles
+MinAlertLevel = error
+
+Packages = https://github.com/adamtheturtle/vale-style-clear-prose/releases/download/v1.1.0/ClearProse.zip
+
+[*.{rst,md}]
+BasedOnStyles = ClearProse


### PR DESCRIPTION
Brings this repository in line with the em dash ban now enforced across the other projects.

The rules come from the pinned [ClearProse](https://github.com/adamtheturtle/vale-style-clear-prose) style package (v1.1.0), configured in a new `.vale.ini`; `vale sync` downloads it into a gitignored `styles/` directory before the lint runs.

The other repositories run Vale as a pre-commit hook, but this one has no pre-commit framework, so it is a `Vale` job in `lint.yml` instead. The job is added to `completion-lint`'s `needs` and its status check, so a failure blocks merges the same way the existing lint matrix does.

Vale shells out to `rst2html` to parse reStructuredText and fails without it, hence `--with docutils`.

Verified locally: Vale reports no alerts over the tracked `.rst` files, and the workflow parses with the gate depending on both jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and CI-only changes with no runtime or application logic impact.
> 
> **Overview**
> Adds **Vale** prose linting in CI so tracked `.md` and `.rst` files follow the pinned **ClearProse** rules (including the em dash ban used in sibling repos).
> 
> A new `.vale.ini` points at ClearProse v1.1.0; `vale sync` pulls styles into a gitignored `styles/` directory. The **`Vale`** job in `lint.yml` runs `vale sync` then lints all tracked markdown and RST via `uvx` with **docutils** for RST parsing. **`completion-lint`** now requires both the existing **`build`** matrix and **`prose`** to succeed before the workflow passes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 968ea5fe5a362a15e4b35e82391443bd8a3d215b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->