### PR TITLE
Report unnamed requirements instead of crashing

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Release History
 ---------------
 
+Next
+
+- A requirement with no distribution name, such as a bare
+  ``git+ssh://...`` URL, now reports an error asking for an ``#egg=<name>``
+  fragment. It previously crashed with an ``AssertionError``.
+
 3.0.0
 
 - Drop support for Python 3.9. Python 3.10 or later is now required.

--- a/pip_check_reqs/common.py
+++ b/pip_check_reqs/common.py
@@ -247,7 +247,15 @@ def find_required_modules(
         requirement_name = install_req_from_line(
             requirement.requirement,
         ).name
-        assert isinstance(requirement_name, str)
+        if requirement_name is None:
+            # A direct URL such as ``git+ssh://git@example.com/org/repo.git``
+            # carries no distribution name, and pip will not learn one without
+            # fetching the project. Skipping the line would silently drop a
+            # requirement and report the modules it provides as missing, so
+            # ask for the name instead of guessing at it.
+            hint = "Add an '#egg=<name>' fragment naming the distribution."
+            msg = f"requirement has no name: {requirement.requirement}. {hint}"
+            raise ValueError(msg)
 
         if ignore_requirements_function(requirement):
             log.debug("ignoring requirement: %s", requirement_name)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -395,5 +395,36 @@ def test_find_required_modules_env_markers(tmp_path: Path) -> None:
     assert reqs == {"ham", "eggs"}
 
 
+def test_find_required_modules_unnamed_requirement(tmp_path: Path) -> None:
+    fake_requirements_file = tmp_path / "requirements.txt"
+    url = "git+ssh://git@example.com/org/repo.git"
+    fake_requirements_file.write_text(f"foobar==1\n{url}\n")
+
+    with pytest.raises(ValueError, match="requirement has no name") as excinfo:
+        common.find_required_modules(
+            ignore_requirements_function=common.ignorer(ignore_cfg=[]),
+            skip_incompatible=False,
+            requirements_filename=fake_requirements_file,
+        )
+
+    assert url in str(excinfo.value)
+    assert "#egg=" in str(excinfo.value)
+
+
+def test_find_required_modules_egg_fragment_names_requirement(
+    tmp_path: Path,
+) -> None:
+    fake_requirements_file = tmp_path / "requirements.txt"
+    url = "git+ssh://git@example.com/org/repo.git#egg=repo"
+    fake_requirements_file.write_text(f"foobar==1\n{url}\n")
+
+    reqs = common.find_required_modules(
+        ignore_requirements_function=common.ignorer(ignore_cfg=[]),
+        skip_incompatible=False,
+        requirements_filename=fake_requirements_file,
+    )
+    assert reqs == {"foobar", "repo"}
+
+
 def test_version_info_shows_version_number() -> None:
     assert __version__ in common.version_info()


### PR DESCRIPTION
## What changed

- raise `ValueError` when a requirement line carries no distribution name, instead of tripping a bare `assert`
- add tests for the error and for the `#egg=` fragment that resolves the name
- note the change under `Next` in the changelog

## Why

A bare direct URL such as `git+ssh://git@example.com/org/repo.git` makes `install_req_from_line(...).name` return `None`, which tripped `assert isinstance(requirement_name, str)` in `find_required_modules`. Users saw an `AssertionError` traceback rather than a message they could act on.

`common.py` already raises `ValueError` for input problems, and both entry points catch `(OSError, ValueError)` and route them through `report_input_error`, so this reuses the existing path and produces a clean `parser.error` exit.

This is the crash reported in #61, which has been open since 2021 and no longer merges. That pull request skipped the offending line instead. Skipping looked appealing but is wrong here: a skipped requirement is still imported, so `find_missing_reqs` would report the modules it provides as missing. Asking for a name pip can actually resolve is the honest failure.

## Validation

- `pytest` — 71 passed
- confirmed the underlying behaviour directly: `install_req_from_line('git+ssh://git@github.com/org/repo.git').name` is `None`, while adding `#egg=repo` yields `'repo'`
- `ruff check`, `ruff format --check` and `mypy` all clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized input validation in requirements parsing with no auth or data-path changes; behavior only affects invalid requirement lines that previously crashed.
> 
> **Overview**
> Bare direct-URL requirement lines (e.g. `git+ssh://...` without a distribution name) no longer trip an internal `assert` in `find_required_modules`. **`find_required_modules`** now raises **`ValueError`** with a message that names the offending line and asks for an **`#egg=<name>`** fragment so pip can resolve the distribution.
> 
> Tests cover the error path and the happy path when `#egg=` is present; the changelog **Next** section documents the behavior change. The new error flows through the existing **`(OSError, ValueError)` → `report_input_error`** handling in the CLI entry points.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29a5a26a109a7531a0a41036ad4c17162af1bbff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->