### PR TITLE
Prepare release 3.1.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,15 @@
 Release History
 ---------------
 
-Next
+3.1.0
 
+- ``pip-missing-reqs`` accepts ``--requirements-file`` more than once, so
+  requirements split across several files are checked as one set.
+- A missing requirements file or source path now reports a concise command
+  line error. A missing requirements file previously surfaced an internal
+  pip exception, and a missing source path was silently ignored.
+- An import from a submodule that does not exist is no longer attributed to
+  an installed parent distribution, which removed a class of false positives.
 - A requirement with no distribution name, such as a bare
   ``git+ssh://...`` URL, now reports an error asking for an ``#egg=<name>``
   fragment. It previously crashed with an ``AssertionError``.

--- a/pip_check_reqs/__init__.py
+++ b/pip_check_reqs/__init__.py
@@ -1,3 +1,3 @@
 """Package for finding missing and extra requirements."""
 
-__version__ = "3.0.0"
+__version__ = "3.1.0"


### PR DESCRIPTION
## What changed

- document three changes that landed since 3.0.0 without changelog entries
- rename `Next` to `3.1.0` and bump `__version__`

## Why

Ten commits have landed since the 3.0.0 tag, four of them user-facing, but only one reached the changelog:

| Pull request | Change | Was documented |
| --- | --- | --- |
| #580 | Handle missing CLI input files | no |
| #581 | Support multiple requirements files | no |
| #582 | Avoid false positives for missing submodules | no |
| #585 | Report unnamed requirements instead of crashing | yes |

A release cut from the previous changelog would have shipped a new feature and two bug fixes silently.

`--requirements-file` can now be repeated in `pip-missing-reqs`, which is a feature rather than a fix, so this is `3.1.0` and not `3.0.1`.

## Validation

- `pytest` — 71 passed
- `vale sync` and Vale over every tracked `.rst` and `.md`, exactly as the `prose` job runs it — 0 errors
- `python -c "from pip_check_reqs import __version__"` reports `3.1.0`

## After merging

`release.sh` tags and uploads to PyPI, and needs credentials, so it is left for a maintainer to run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and version metadata only; no runtime or CLI behavior changes in this diff.
> 
> **Overview**
> Prepares the **3.1.0** release by bumping `__version__` in `pip_check_reqs/__init__.py` and replacing the changelog **Next** section with a **3.1.0** entry.
> 
> The new changelog bullets document user-facing work that shipped after 3.0.0 but was not yet listed: repeatable `--requirements-file` on `pip-missing-reqs`, clearer errors for missing requirements files or scan paths, and fewer false positives when imports reference non-existent submodules (alongside the already-documented unnamed-requirement error).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e33b666be6566e23e1147b5f40dd4bc50fbe7ab3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->