### PR TITLE
Switch Vale to the upstream ai-tells package

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -58,7 +58,7 @@ jobs:
       - name: "Install uv"
         uses: astral-sh/setup-uv@v9.0.0
 
-      # ClearProse bans em dashes.  The style package is pinned in
+      # ai-tells bans em dashes and other AI-written prose patterns.  The style package is pinned in
       # ``.vale.ini`` and ``vale sync`` downloads it into the gitignored
       # ``styles`` directory.  Vale needs ``rst2html`` from Docutils on the
       # ``PATH`` to parse reStructuredText.

--- a/.vale.ini
+++ b/.vale.ini
@@ -12,4 +12,3 @@ ai-tells.ColonUsage = NO
 ai-tells.DoubleHyphen = NO
 ai-tells.EmptyPadding = NO
 ai-tells.FormalTransitions = NO
-

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,7 +1,15 @@
 StylesPath = styles
 MinAlertLevel = error
 
-Packages = https://github.com/adamtheturtle/vale-style-clear-prose/releases/download/v1.1.0/ClearProse.zip
+Packages = https://github.com/tbhb/vale-ai-tells/releases/download/v1.29.0/ai-tells.zip
 
 [*.{rst,md}]
-BasedOnStyles = ClearProse
+BasedOnStyles = ai-tells
+
+# These rules misclassify established technical, example, or release-note prose
+# in this repository. All other ai-tells rules remain enforced.
+ai-tells.ColonUsage = NO
+ai-tells.DoubleHyphen = NO
+ai-tells.EmptyPadding = NO
+ai-tells.FormalTransitions = NO
+


### PR DESCRIPTION
## What changed

- Replace the single-rule `ClearProse` package with [`tbhb/vale-ai-tells`](https://github.com/tbhb/vale-ai-tells) v1.29.0.
- Keep all compatible ai-tells rules enabled.
- Disable only rules that flag established technical, example, or release-note prose already present in this repository.
- Update the Vale workflow/hook comment where one names the old package.

## Why

The upstream package covers em dashes as well as a much broader set of patterns associated with AI-written prose. Repository-specific exceptions avoid rewriting valid technical terminology and reference material merely to satisfy a general-audience heuristic.

## Validation

- `uvx --with docutils vale@3.13.0.0` over every tracked `*.rst` and `*.md` file
- Result: passed with zero errors

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change to prose linting styles; no runtime, security, or application logic impact.
> 
> **Overview**
> Replaces the Vale `ClearProse` style package with upstream **`ai-tells` v1.29.0**, which covers em dashes plus a broader set of AI-written prose patterns.
> 
> In `.vale.ini`, disables four rules (`ColonUsage`, `DoubleHyphen`, `EmptyPadding`, `FormalTransitions`) that misclassify existing technical and release-note prose. Updates the related workflow comment accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d22687554dc7f577d61131faf4b6fa0df89c10f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->