### PR TITLE
Configure mypy to respect gitignore

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,6 +172,7 @@ keep_full_version = true
 max_supported_python = "3.14"
 
 [tool.mypy]
+exclude_gitignore = true
 strict = true
 
 [tool.pyright]


### PR DESCRIPTION
## Summary

- configure mypy with `exclude_gitignore = true`
- prevent files ignored by Git from being included in mypy discovery

## Impact

Mypy will respect the project's `.gitignore` rules when discovering files. This avoids type-checking generated, local, or otherwise ignored files.

## Validation

- formatted and parsed `pyproject.toml` with `pyproject-fmt`
- verified the branch diff is exactly one added line in `pyproject.toml`
- ran Git whitespace validation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single tooling config change in `pyproject.toml` with no runtime, security, or application logic impact.
> 
> **Overview**
> Configures mypy with `exclude_gitignore = true` so type checking skips files ignored by Git (for example generated artifacts and local environments) when discovering sources.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 850fb71008d9ae6ad4ddead2feda25b6f6db0aae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->