### PR TITLE
Report a clear error when a source file cannot be parsed

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,9 @@ Release History
 - A missing requirements file or source path now reports a concise command
   line error. A missing requirements file previously surfaced an internal
   pip exception, and a missing source path was silently ignored.
+- A source file which cannot be parsed now reports a command line error
+  naming the file and the line at fault. It previously showed a
+  ``SyntaxError`` traceback.
 - An import from a submodule that does not exist is no longer attributed to
   an installed parent distribution, which removed a class of false positives.
 - A requirement with no distribution name, such as a bare

--- a/pip_check_reqs/common.py
+++ b/pip_check_reqs/common.py
@@ -226,7 +226,15 @@ def find_imported_modules(
             log.debug("scanning: %s", filename)
             content = filename.read_text(encoding="utf-8")
             vis.set_location(location=str(filename))
-            vis.visit(ast.parse(content, str(filename)))
+            try:
+                tree = ast.parse(content, str(filename))
+            except SyntaxError as exc:
+                # ``ast`` knows where the problem is, but the default traceback
+                # buries that behind a stack trace, so we surface it as an
+                # input error with the file and line which could not be parsed.
+                msg = f"could not parse {filename}:{exc.lineno}: {exc.msg}"
+                raise ValueError(msg) from exc
+            vis.visit(tree)
     return vis.finalise()
 
 

--- a/spelling_private_dict.txt
+++ b/spelling_private_dict.txt
@@ -5,3 +5,4 @@ pytest
 reportPrivateUsage
 reportUnknownMemberType
 reqs
+traceback

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -220,6 +220,30 @@ def test_find_imported_modules_no_spec(tmp_path: Path) -> None:
     assert set(result.keys()) == set()
 
 
+def test_find_imported_modules_syntax_error(tmp_path: Path) -> None:
+    """A file which cannot be parsed gives an error naming file and line."""
+    spam = tmp_path / "spam.py"
+    spam.write_text(
+        data=textwrap.dedent(
+            text="""\
+            import os
+
+            def (
+            """,
+        ),
+    )
+
+    with pytest.raises(
+        expected_exception=ValueError,
+        match=re.escape(f"could not parse {spam}:3: "),
+    ):
+        common.find_imported_modules(
+            paths=[tmp_path],
+            ignore_files_function=common.ignorer(ignore_cfg=[]),
+            ignore_modules_function=common.ignorer(ignore_cfg=[]),
+        )
+
+
 def test_find_imported_modules_period(tmp_path: Path) -> None:
     """Imported modules are found if the package name contains a period.
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -233,9 +233,10 @@ def test_find_imported_modules_syntax_error(tmp_path: Path) -> None:
         ),
     )
 
+    expected_message = f"could not parse {spam}:3: invalid syntax"
     with pytest.raises(
         expected_exception=ValueError,
-        match=re.escape(f"could not parse {spam}:3: "),
+        match=f"^{re.escape(expected_message)}$",
     ):
         common.find_imported_modules(
             paths=[tmp_path],

--- a/tests/test_find_extra_reqs.py
+++ b/tests/test_find_extra_reqs.py
@@ -146,6 +146,32 @@ def test_main_missing_source_path(
     assert err.endswith(f"error: source path not found: {source_dir}\n")
 
 
+def test_main_source_file_parse_error(
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    requirements_file = tmp_path / "requirements.txt"
+    requirements_file.touch()
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    source_file = source_dir / "spam.py"
+    source_file.write_text(data="def (\n")
+
+    with pytest.raises(SystemExit) as excinfo:
+        find_extra_reqs.main(
+            arguments=[
+                "--requirements",
+                str(requirements_file),
+                str(source_dir),
+            ],
+        )
+
+    expected_code = 2
+    assert excinfo.value.code == expected_code
+    err = capsys.readouterr().err
+    assert f"error: could not parse {source_file}:1: " in err
+
+
 def test_main_debug_reraises_input_error(tmp_path: Path) -> None:
     source_dir = tmp_path / "source"
     source_dir.mkdir()

--- a/tests/test_find_extra_reqs.py
+++ b/tests/test_find_extra_reqs.py
@@ -169,7 +169,9 @@ def test_main_source_file_parse_error(
     expected_code = 2
     assert excinfo.value.code == expected_code
     err = capsys.readouterr().err
-    assert f"error: could not parse {source_file}:1: " in err
+    assert err.endswith(
+        f"error: could not parse {source_file}:1: invalid syntax\n",
+    )
 
 
 def test_main_debug_reraises_input_error(tmp_path: Path) -> None:

--- a/tests/test_find_missing_reqs.py
+++ b/tests/test_find_missing_reqs.py
@@ -209,7 +209,9 @@ def test_main_source_file_parse_error(
     expected_code = 2
     assert excinfo.value.code == expected_code
     err = capsys.readouterr().err
-    assert f"error: could not parse {source_file}:1: " in err
+    assert err.endswith(
+        f"error: could not parse {source_file}:1: invalid syntax\n",
+    )
 
 
 def test_main_debug_reraises_input_error(tmp_path: Path) -> None:

--- a/tests/test_find_missing_reqs.py
+++ b/tests/test_find_missing_reqs.py
@@ -186,6 +186,32 @@ def test_main_missing_source_path(
     assert err.endswith(f"error: source path not found: {source_dir}\n")
 
 
+def test_main_source_file_parse_error(
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    requirements_file = tmp_path / "requirements.txt"
+    requirements_file.touch()
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    source_file = source_dir / "spam.py"
+    source_file.write_text(data="def (\n")
+
+    with pytest.raises(SystemExit) as excinfo:
+        find_missing_reqs.main(
+            arguments=[
+                "--requirements",
+                str(requirements_file),
+                str(source_dir),
+            ],
+        )
+
+    expected_code = 2
+    assert excinfo.value.code == expected_code
+    err = capsys.readouterr().err
+    assert f"error: could not parse {source_file}:1: " in err
+
+
 def test_main_debug_reraises_input_error(tmp_path: Path) -> None:
     source_dir = tmp_path / "source"
     source_dir.mkdir()


### PR DESCRIPTION
Closes #50.

`find_imported_modules` called `ast.parse` without handling `SyntaxError`, so a source file with invalid syntax produced a raw traceback:

```
  File "/tmp/source/spam.py", line 1
    def (
        ^
SyntaxError: invalid syntax
```

Now the error is re-raised as a `ValueError` naming the file and the line, which the existing input-error handling in both commands turns into a concise message:

```
pip-missing-reqs: error: could not parse /tmp/source/spam.py:1: invalid syntax
```

`--debug` still re-raises so the original traceback stays reachable via the exception chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized error-handling change in AST scanning with no impact on auth, data, or requirement matching logic.
> 
> **Overview**
> **Unparseable source files** now fail with a short CLI message (`could not parse <path>:<line>: <reason>`) instead of a raw `SyntaxError` traceback.
> 
> `find_imported_modules` catches `SyntaxError` from `ast.parse` and re-raises a `ValueError` with file and line details. Both `pip-missing-reqs` and `pip-extra-reqs` already route `ValueError` through `report_input_error`, so users see the same style of input error as for missing paths or requirements files. With `--debug`, the original exception is still re-raised (chained from the `ValueError`).
> 
> Tests cover the common helper and both entrypoints; the 3.1.0 changelog notes the behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7bb05dbe1e5fbc7a625dccb1d8a2e560c8599600. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->