### PR TITLE
Assert on exact strings instead of substrings in tests

### DIFF
--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -407,8 +407,9 @@ def test_find_required_modules_unnamed_requirement(tmp_path: Path) -> None:
             requirements_filename=fake_requirements_file,
         )
 
-    assert url in str(excinfo.value)
-    assert "#egg=" in str(excinfo.value)
+    hint = "Add an '#egg=<name>' fragment naming the distribution."
+    expected_message = f"requirement has no name: {url}. {hint}"
+    assert str(excinfo.value) == expected_message
 
 
 def test_find_required_modules_egg_fragment_names_requirement(
@@ -427,4 +428,12 @@ def test_find_required_modules_egg_fragment_names_requirement(
 
 
 def test_version_info_shows_version_number() -> None:
-    assert __version__ in common.version_info()
+    major, minor, patch = sys.version_info[:3]
+    python_version = f"{major}.{minor}.{patch}"
+    parent_directory = Path(common.__file__).parent.resolve()
+    expected_version_info = (
+        f"pip-check-reqs {__version__} "
+        f"from {parent_directory} "
+        f"(python {python_version})"
+    )
+    assert common.version_info() == expected_version_info


### PR DESCRIPTION
Replaces the substring assertions in `tests/test_common.py` with exact equality checks. `test_find_required_modules_unnamed_requirement` now compares the raised `ValueError` message against the full expected string rather than checking for the URL and `#egg=` separately, and `test_version_info_shows_version_number` builds the complete expected `version_info()` output instead of only checking that the version number appears somewhere in it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only assertion updates with no changes to library behavior or runtime paths.
> 
> **Overview**
> Tightens two tests in `tests/test_common.py` so they validate **full expected strings** instead of partial substring checks.
> 
> For unnamed VCS requirements, `test_find_required_modules_unnamed_requirement` now compares the raised `ValueError` to the complete message (URL plus the `#egg=` hint). For `test_version_info_shows_version_number`, the test builds the entire `version_info()` line—package version, install path, and Python version—and asserts equality.
> 
> No production code changes; behavior under test is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0339b70f98fcf10c94dfda536c793ff048ed40f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->