### PR TITLE
Report unnamed requirements from pip-missing-reqs too

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,7 +16,8 @@ Release History
   an installed parent distribution, which removed a class of false positives.
 - A requirement with no distribution name, such as a bare
   ``git+ssh://...`` URL, now reports an error asking for an ``#egg=<name>``
-  fragment. It previously crashed with an ``AssertionError``.
+  fragment in both commands. It previously crashed with an
+  ``AssertionError``.
 
 3.0.0
 

--- a/pip_check_reqs/find_missing_reqs.py
+++ b/pip_check_reqs/find_missing_reqs.py
@@ -10,9 +10,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from packaging.utils import NormalizedName, canonicalize_name
-from pip._internal.network.session import PipSession
-from pip._internal.req.constructors import install_req_from_line
-from pip._internal.req.req_file import parse_requirements
 
 from pip_check_reqs import common
 
@@ -89,17 +86,11 @@ def find_missing_reqs(
         requirements_filename,
         *additional_requirements_filenames,
     ]:
-        for requirement in parse_requirements(
-            str(filename),
-            session=PipSession(),
-        ):
-            requirement_name = install_req_from_line(
-                requirement.requirement,
-            ).name
-
-            assert isinstance(requirement_name, str)
-            log.debug("found requirement: %s", requirement_name)
-            explicit.add(canonicalize_name(requirement_name))
+        explicit |= common.find_required_modules(
+            ignore_requirements_function=common.ignorer(ignore_cfg=[]),
+            skip_incompatible=False,
+            requirements_filename=filename,
+        )
 
     return [(name, used[name]) for name in used if name not in explicit]
 

--- a/tests/test_find_missing_reqs.py
+++ b/tests/test_find_missing_reqs.py
@@ -214,6 +214,56 @@ def test_main_source_file_parse_error(
     )
 
 
+def test_main_unnamed_requirement(
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    requirements_file = tmp_path / "requirements.txt"
+    url = "git+ssh://git@example.com/org/repo.git"
+    requirements_file.write_text(f"{url}\n")
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    (source_dir / "source.py").write_text("import pytest\n")
+
+    with pytest.raises(SystemExit) as excinfo:
+        find_missing_reqs.main(
+            arguments=[
+                "--requirements",
+                str(requirements_file),
+                str(source_dir),
+            ],
+        )
+
+    expected_code = 2
+    assert excinfo.value.code == expected_code
+    err = capsys.readouterr().err
+    hint = "Add an '#egg=<name>' fragment naming the distribution."
+    assert err.endswith(f"error: requirement has no name: {url}. {hint}\n")
+
+
+def test_main_egg_fragment_names_requirement(
+    *,
+    caplog: pytest.LogCaptureFixture,
+    tmp_path: Path,
+) -> None:
+    requirements_file = tmp_path / "requirements.txt"
+    url = "git+ssh://git@example.com/org/repo.git#egg=pytest"
+    requirements_file.write_text(f"{url}\n")
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    (source_dir / "source.py").write_text("import pytest\n")
+
+    find_missing_reqs.main(
+        arguments=[
+            "--requirements",
+            str(requirements_file),
+            str(source_dir),
+        ],
+    )
+
+    assert not caplog.records
+
+
 def test_main_debug_reraises_input_error(tmp_path: Path) -> None:
     source_dir = tmp_path / "source"
     source_dir.mkdir()


### PR DESCRIPTION
`pip-missing-reqs` kept its own copy of the pip requirement-parsing loop, which still asserted that every requirement had a distribution name. A bare `git+ssh://...` requirement therefore crashed with a bare `AssertionError`, while `pip-extra-reqs` already reported a clear error asking for an `#egg=<name>` fragment.

Both commands now go through `common.find_required_modules`, so the diagnostic — and any later change to it — applies to both.

Fixes #414

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactors requirement loading to shared code with added tests; behavior change is limited to clearer errors for unnamed requirements.
> 
> **Overview**
> **`pip-missing-reqs`** no longer parses requirements with its own pip loop (and the `assert` on distribution names). It now unions names from **`common.find_required_modules`** for each requirements file, matching **`pip-extra-reqs`**.
> 
> Bare VCS URLs without a name now exit with a clear **`#egg=<name>`** hint instead of an **`AssertionError`**. The changelog notes this applies to both commands.
> 
> Tests cover an unnamed `git+ssh://...` line (exit 2 + message) and a URL with `#egg=pytest` (no false missing-reqs warning).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0dab2c981f23212b126073b81d74f58a5d683225. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->