### PR TITLE
Do not crash on ignore globs across Windows drives

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,8 @@ Release History
   ``git+ssh://...`` URL, now reports an error asking for an ``#egg=<name>``
   fragment in both commands. It previously crashed with an
   ``AssertionError``.
+- On Windows, an ignore glob no longer crashes with a ``ValueError`` when a
+  source file is on a different drive to the working directory.
 
 3.0.0
 

--- a/pip_check_reqs/common.py
+++ b/pip_check_reqs/common.py
@@ -6,7 +6,6 @@ import ast
 import fnmatch
 import importlib.metadata
 import logging
-import os
 import sys
 from dataclasses import dataclass, field
 from functools import cache
@@ -324,6 +323,7 @@ def ignorer(*, ignore_cfg: list[str]) -> Callable[..., bool]:
         candidate: str | ParsedRequirement,
         ignore_cfg: list[str] = ignore_cfg,
     ) -> bool:
+        working_directory = Path.cwd()
         for ignore in ignore_cfg:
             if isinstance(candidate, str):
                 candidate_path = candidate
@@ -336,8 +336,20 @@ def ignorer(*, ignore_cfg: list[str]) -> Callable[..., bool]:
 
             if fnmatch.fnmatch(candidate_path, ignore):
                 return True
-            if fnmatch.fnmatch(os.path.relpath(candidate_path), ignore):
-                return True
+
+            # Files are given as absolute paths, while an ignore glob is
+            # usually written relative to the working directory, so we match
+            # against the relative path as well.
+            # We use ``Path`` rather than ``os.path.relpath``, which raises
+            # ``ValueError`` on Windows for a path on a different drive to the
+            # working directory.
+            candidate_as_path = Path(candidate_path)
+            if candidate_as_path.is_relative_to(working_directory):
+                relative_candidate = candidate_as_path.relative_to(
+                    working_directory,
+                )
+                if fnmatch.fnmatch(str(relative_candidate), ignore):
+                    return True
         return False
 
     return ignorer_function

--- a/pip_check_reqs/common.py
+++ b/pip_check_reqs/common.py
@@ -6,6 +6,7 @@ import ast
 import fnmatch
 import importlib.metadata
 import logging
+import os
 import sys
 from dataclasses import dataclass, field
 from functools import cache
@@ -340,12 +341,17 @@ def ignorer(*, ignore_cfg: list[str]) -> Callable[..., bool]:
             # Files are given as absolute paths, while an ignore glob is
             # usually written relative to the working directory, so we match
             # against the relative path as well.
+            # A path may contain ``..``, for example when the source to scan
+            # was given as ``scripts/../src``, so we normalize it before
+            # comparing.
             # We use ``Path`` rather than ``os.path.relpath``, which raises
             # ``ValueError`` on Windows for a path on a different drive to the
             # working directory.
-            candidate_as_path = Path(candidate_path)
-            if candidate_as_path.is_relative_to(working_directory):
-                relative_candidate = candidate_as_path.relative_to(
+            absolute_candidate = Path(
+                os.path.normpath(working_directory / candidate_path),
+            )
+            if absolute_candidate.is_relative_to(working_directory):
+                relative_candidate = absolute_candidate.relative_to(
                     working_directory,
                 )
                 if fnmatch.fnmatch(str(relative_candidate), ignore):

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -383,6 +383,8 @@ def test_find_imported_modules_advanced(
         (["spam*"], "eggs", False),
         (["spam"], str(Path.cwd() / "spam"), True),
         (["eggs"], str(Path.cwd() / "spam"), False),
+        (["spam"], str(Path.cwd() / "eggs" / ".." / "spam"), True),
+        (["spam"], str(Path("eggs") / ".." / "spam"), True),
         (["spam"], str(Path.cwd().parent / "spam"), False),
     ],
 )

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -382,6 +382,8 @@ def test_find_imported_modules_advanced(
         (["spam*"], "spam.ham", True),
         (["spam*"], "eggs", False),
         (["spam"], str(Path.cwd() / "spam"), True),
+        (["eggs"], str(Path.cwd() / "spam"), False),
+        (["spam"], str(Path.cwd().parent / "spam"), False),
     ],
 )
 def test_ignorer(
@@ -392,6 +394,23 @@ def test_ignorer(
 ) -> None:
     ignorer = common.ignorer(ignore_cfg=ignore_cfg)
     assert ignorer(candidate) == result
+
+
+@pytest.mark.skipif(
+    condition=platform.system() != "Windows",
+    reason="Only Windows has drives, which is what this test is about",
+)
+def test_ignorer_other_drive() -> None:  # pragma: no cover
+    """A candidate on another drive than the working directory is handled.
+
+    Making such a path relative to the working directory is impossible, and
+    that used to raise an error.
+    """
+    working_directory_drive = Path.cwd().drive
+    other_drive = "Y:" if working_directory_drive.upper() == "Z:" else "Z:"
+    ignorer = common.ignorer(ignore_cfg=["eggs"])
+
+    assert not ignorer(rf"{other_drive}\eggs\spam.py")
 
 
 def test_find_required_modules(tmp_path: Path) -> None:


### PR DESCRIPTION
`common.ignorer` matched each candidate against an ignore glob twice: once as given, and once as a path relative to the working directory computed with `os.path.relpath`. On Windows that raises `ValueError` when the candidate is on a different drive to the working directory, so any run over source on another drive crashed.

This uses `Path.is_relative_to` / `Path.relative_to` instead, which return `False` rather than raising for that case. Candidates outside the working directory were already effectively unmatchable by a relative glob, since `relpath` gave them a `../` prefix, so realistic behaviour is unchanged. Adds a Windows-only regression test using another drive letter, two more `test_ignorer` cases, and a changelog entry.

Fixes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized bug fix in ignore-glob matching with tests; intended behavior for in-tree paths is unchanged.
> 
> **Overview**
> **Fixes a Windows crash** when scanning source on a drive different from the working directory while using ignore globs.
> 
> `common.ignorer` no longer uses `os.path.relpath` for the second glob match against paths relative to the cwd. It now resolves the candidate under the cwd, and only runs that relative match when `Path.is_relative_to` says the file is under the working directory—avoiding the cross-drive `ValueError`. Paths outside the cwd still do not match cwd-relative globs, same as before when `relpath` produced `../` prefixes.
> 
> Adds regression coverage (including a Windows-only other-drive case), extra `test_ignorer` cases for `..` normalization, and a changelog note. Fixes #67.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1da6b066230657386b0c85a797c55de0ba1bcffb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->