### PR TITLE
Warn when running from outside the active virtual environment

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,9 @@ Release History
   ``AssertionError``.
 - On Windows, an ignore glob no longer crashes with a ``ValueError`` when a
   source file is on a different drive to the working directory.
+- Both commands now warn when they are run from outside the active virtual
+  environment, as the results then describe the environment the command is
+  installed in rather than the active one.
 
 3.0.0
 

--- a/pip_check_reqs/common.py
+++ b/pip_check_reqs/common.py
@@ -29,7 +29,7 @@ from . import __version__
 if TYPE_CHECKING:
     import argparse
     from collections.abc import Callable, Generator, Iterable
-    from typing import NoReturn
+    from typing import NoReturn, TextIO
 
 log = logging.getLogger(__name__)
 
@@ -362,15 +362,21 @@ def ignorer(*, ignore_cfg: list[str]) -> Callable[..., bool]:
 
 
 def _yellow(*, message: str) -> str:
-    if not sys.stderr.isatty():
-        return message
     yellow = "\033[33m"
     reset = "\033[0m"
     return f"{yellow}{message}{reset}"
 
 
-def warn_if_not_in_active_virtualenv() -> None:
-    """Warn when we are not running from the active virtual environment.
+def wrong_environment_warning(
+    *,
+    running_prefix: Path,
+    active_virtualenv: str | None,
+    color: bool,
+) -> str | None:
+    """Return a warning if we do not run from the active virtual environment.
+
+    Return ``None`` when there is nothing to warn about, which is when no
+    virtual environment is active or when we run from the active one.
 
     A shell caches the paths of the commands it has run, so right after
     ``pip install pip-check-reqs`` in a new virtual environment, the shell
@@ -379,26 +385,35 @@ def warn_if_not_in_active_virtualenv() -> None:
     That command inspects the packages installed alongside it, not the ones
     in the active environment, so the results describe the wrong environment.
     """
-    virtual_env = os.environ.get("VIRTUAL_ENV")
-    if not virtual_env:
-        return
+    if not active_virtualenv:
+        return None
 
-    active_prefix = Path(virtual_env).resolve()
-    running_prefix = Path(sys.prefix).resolve()
-    if active_prefix == running_prefix:
-        return
+    active_prefix = Path(active_virtualenv).resolve()
+    resolved_running_prefix = running_prefix.resolve()
+    if active_prefix == resolved_running_prefix:
+        return None
 
-    message = _yellow(
-        message=(
-            f"WARNING: Running from {running_prefix}, but the active "
-            f"virtual environment is {active_prefix}. "
-            "Results describe the environment pip-check-reqs is installed "
-            "in. "
-            "Install pip-check-reqs in the active virtual environment, and "
-            'run "hash -r" ("rehash" in zsh), to check that environment.'
-        ),
+    message = (
+        f"WARNING: Running from {resolved_running_prefix}, but the active "
+        f"virtual environment is {active_prefix}. "
+        "Results describe the environment pip-check-reqs is installed in. "
+        "Install pip-check-reqs in the active virtual environment, and "
+        'run "hash -r" ("rehash" in zsh), to check that environment.'
     )
-    sys.stderr.write(message + "\n")
+    if color:
+        return _yellow(message=message)
+    return message
+
+
+def report_wrong_environment(*, stream: TextIO) -> None:
+    """Write a warning to ``stream`` if we run from the wrong environment."""
+    warning = wrong_environment_warning(
+        running_prefix=Path(sys.prefix),
+        active_virtualenv=os.environ.get("VIRTUAL_ENV"),
+        color=stream.isatty(),
+    )
+    if warning is not None:
+        stream.write(warning + "\n")
 
 
 def version_info() -> str:

--- a/pip_check_reqs/common.py
+++ b/pip_check_reqs/common.py
@@ -361,6 +361,46 @@ def ignorer(*, ignore_cfg: list[str]) -> Callable[..., bool]:
     return ignorer_function
 
 
+def _yellow(*, message: str) -> str:
+    if not sys.stderr.isatty():
+        return message
+    yellow = "\033[33m"
+    reset = "\033[0m"
+    return f"{yellow}{message}{reset}"
+
+
+def warn_if_not_in_active_virtualenv() -> None:
+    """Warn when we are not running from the active virtual environment.
+
+    A shell caches the paths of the commands it has run, so right after
+    ``pip install pip-check-reqs`` in a new virtual environment, the shell
+    can still resolve ``pip-missing-reqs`` to a command from another
+    environment.
+    That command inspects the packages installed alongside it, not the ones
+    in the active environment, so the results describe the wrong environment.
+    """
+    virtual_env = os.environ.get("VIRTUAL_ENV")
+    if not virtual_env:
+        return
+
+    active_prefix = Path(virtual_env).resolve()
+    running_prefix = Path(sys.prefix).resolve()
+    if active_prefix == running_prefix:
+        return
+
+    message = _yellow(
+        message=(
+            f"WARNING: Running from {running_prefix}, but the active "
+            f"virtual environment is {active_prefix}. "
+            "Results describe the environment pip-check-reqs is installed "
+            "in. "
+            "Install pip-check-reqs in the active virtual environment, and "
+            'run "hash -r" ("rehash" in zsh), to check that environment.'
+        ),
+    )
+    sys.stderr.write(message + "\n")
+
+
 def version_info() -> str:
     major, minor, patch = sys.version_info[:3]
     python_version = f"{major}.{minor}.{patch}"

--- a/pip_check_reqs/find_extra_reqs.py
+++ b/pip_check_reqs/find_extra_reqs.py
@@ -189,6 +189,7 @@ def main(arguments: list[str] | None = None) -> None:
     common.log.setLevel(level)
 
     log.info(common.version_info())
+    common.warn_if_not_in_active_virtualenv()
 
     try:
         common.validate_requirements_file(

--- a/pip_check_reqs/find_extra_reqs.py
+++ b/pip_check_reqs/find_extra_reqs.py
@@ -189,7 +189,7 @@ def main(arguments: list[str] | None = None) -> None:
     common.log.setLevel(level)
 
     log.info(common.version_info())
-    common.warn_if_not_in_active_virtualenv()
+    common.report_wrong_environment(stream=sys.stderr)
 
     try:
         common.validate_requirements_file(

--- a/pip_check_reqs/find_missing_reqs.py
+++ b/pip_check_reqs/find_missing_reqs.py
@@ -174,6 +174,7 @@ def main(arguments: list[str] | None = None) -> None:
     common.log.setLevel(level)
 
     log.info(common.version_info())
+    common.warn_if_not_in_active_virtualenv()
 
     try:
         for requirements_filename in requirements_filenames:

--- a/pip_check_reqs/find_missing_reqs.py
+++ b/pip_check_reqs/find_missing_reqs.py
@@ -174,7 +174,7 @@ def main(arguments: list[str] | None = None) -> None:
     common.log.setLevel(level)
 
     log.info(common.version_info())
-    common.warn_if_not_in_active_virtualenv()
+    common.report_wrong_environment(stream=sys.stderr)
 
     try:
         for requirements_filename in requirements_filenames:

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -483,3 +483,70 @@ def test_version_info_shows_version_number() -> None:
         f"(python {python_version})"
     )
     assert common.version_info() == expected_version_info
+
+
+def test_no_warning_without_active_virtualenv(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+    common.warn_if_not_in_active_virtualenv()
+    assert capsys.readouterr().err == ""
+
+
+def test_no_warning_when_running_from_active_virtualenv(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("VIRTUAL_ENV", str(tmp_path))
+    monkeypatch.setattr(sys, "prefix", str(tmp_path))
+    common.warn_if_not_in_active_virtualenv()
+    assert capsys.readouterr().err == ""
+
+
+def test_warning_when_running_from_another_environment(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    active_prefix = tmp_path / "active"
+    running_prefix = tmp_path / "running"
+    monkeypatch.setenv("VIRTUAL_ENV", str(active_prefix))
+    monkeypatch.setattr(sys, "prefix", str(running_prefix))
+
+    common.warn_if_not_in_active_virtualenv()
+
+    expected_message = (
+        f"WARNING: Running from {running_prefix}, but the active "
+        f"virtual environment is {active_prefix}. "
+        "Results describe the environment pip-check-reqs is installed in. "
+        "Install pip-check-reqs in the active virtual environment, and "
+        'run "hash -r" ("rehash" in zsh), to check that environment.\n'
+    )
+    assert capsys.readouterr().err == expected_message
+
+
+def test_warning_is_yellow_on_a_terminal(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    active_prefix = tmp_path / "active"
+    running_prefix = tmp_path / "running"
+    monkeypatch.setenv("VIRTUAL_ENV", str(active_prefix))
+    monkeypatch.setattr(sys, "prefix", str(running_prefix))
+    monkeypatch.setattr(sys.stderr, "isatty", lambda: True)
+
+    common.warn_if_not_in_active_virtualenv()
+
+    expected_message = (
+        "\033[33m"
+        f"WARNING: Running from {running_prefix}, but the active "
+        f"virtual environment is {active_prefix}. "
+        "Results describe the environment pip-check-reqs is installed in. "
+        "Install pip-check-reqs in the active virtual environment, and "
+        'run "hash -r" ("rehash" in zsh), to check that environment.'
+        "\033[0m\n"
+    )
+    assert capsys.readouterr().err == expected_message

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -485,68 +485,63 @@ def test_version_info_shows_version_number() -> None:
     assert common.version_info() == expected_version_info
 
 
-def test_no_warning_without_active_virtualenv(
-    capsys: pytest.CaptureFixture[str],
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.delenv("VIRTUAL_ENV", raising=False)
-    common.warn_if_not_in_active_virtualenv()
-    assert capsys.readouterr().err == ""
-
-
-def test_no_warning_when_running_from_active_virtualenv(
-    capsys: pytest.CaptureFixture[str],
-    monkeypatch: pytest.MonkeyPatch,
+def test_no_wrong_environment_warning_without_active_virtualenv(
     tmp_path: Path,
 ) -> None:
-    monkeypatch.setenv("VIRTUAL_ENV", str(tmp_path))
-    monkeypatch.setattr(sys, "prefix", str(tmp_path))
-    common.warn_if_not_in_active_virtualenv()
-    assert capsys.readouterr().err == ""
-
-
-def test_warning_when_running_from_another_environment(
-    capsys: pytest.CaptureFixture[str],
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    active_prefix = tmp_path / "active"
-    running_prefix = tmp_path / "running"
-    monkeypatch.setenv("VIRTUAL_ENV", str(active_prefix))
-    monkeypatch.setattr(sys, "prefix", str(running_prefix))
-
-    common.warn_if_not_in_active_virtualenv()
-
-    expected_message = (
-        f"WARNING: Running from {running_prefix}, but the active "
-        f"virtual environment is {active_prefix}. "
-        "Results describe the environment pip-check-reqs is installed in. "
-        "Install pip-check-reqs in the active virtual environment, and "
-        'run "hash -r" ("rehash" in zsh), to check that environment.\n'
+    warning = common.wrong_environment_warning(
+        running_prefix=tmp_path,
+        active_virtualenv=None,
+        color=False,
     )
-    assert capsys.readouterr().err == expected_message
+    assert warning is None
 
 
-def test_warning_is_yellow_on_a_terminal(
-    capsys: pytest.CaptureFixture[str],
-    monkeypatch: pytest.MonkeyPatch,
+def test_no_wrong_environment_warning_from_active_virtualenv(
     tmp_path: Path,
 ) -> None:
+    warning = common.wrong_environment_warning(
+        running_prefix=tmp_path,
+        active_virtualenv=str(tmp_path),
+        color=False,
+    )
+    assert warning is None
+
+
+def test_wrong_environment_warning(tmp_path: Path) -> None:
     active_prefix = tmp_path / "active"
     running_prefix = tmp_path / "running"
-    monkeypatch.setenv("VIRTUAL_ENV", str(active_prefix))
-    monkeypatch.setattr(sys, "prefix", str(running_prefix))
-    monkeypatch.setattr(sys.stderr, "isatty", lambda: True)
 
-    common.warn_if_not_in_active_virtualenv()
+    warning = common.wrong_environment_warning(
+        running_prefix=running_prefix,
+        active_virtualenv=str(active_prefix),
+        color=False,
+    )
 
-    expected_message = (
-        "\033[33m"
+    expected_warning = (
         f"WARNING: Running from {running_prefix}, but the active "
         f"virtual environment is {active_prefix}. "
         "Results describe the environment pip-check-reqs is installed in. "
         "Install pip-check-reqs in the active virtual environment, and "
         'run "hash -r" ("rehash" in zsh), to check that environment.'
-        "\033[0m\n"
     )
-    assert capsys.readouterr().err == expected_message
+    assert warning == expected_warning
+
+
+def test_wrong_environment_warning_in_color(tmp_path: Path) -> None:
+    active_prefix = tmp_path / "active"
+    running_prefix = tmp_path / "running"
+
+    warning = common.wrong_environment_warning(
+        running_prefix=running_prefix,
+        active_virtualenv=str(active_prefix),
+        color=True,
+    )
+
+    plain_warning = common.wrong_environment_warning(
+        running_prefix=running_prefix,
+        active_virtualenv=str(active_prefix),
+        color=False,
+    )
+    yellow = "\033[33m"
+    reset = "\033[0m"
+    assert warning == f"{yellow}{plain_warning}{reset}"

--- a/tests/test_find_extra_reqs.py
+++ b/tests/test_find_extra_reqs.py
@@ -6,15 +6,12 @@ import logging
 import re
 import sys
 import textwrap
-from typing import TYPE_CHECKING
+from pathlib import Path
 
 import pip  # This happens to be installed in the test environment.
 import pytest
 
 from pip_check_reqs import common, find_extra_reqs
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 
 def test_find_extra_reqs(tmp_path: Path) -> None:
@@ -256,9 +253,7 @@ def test_main_warns_when_run_from_another_environment(
     (source_dir / "source.py").write_text("import pprint")
 
     active_prefix = tmp_path / "active"
-    running_prefix = tmp_path / "running"
     monkeypatch.setenv("VIRTUAL_ENV", str(active_prefix))
-    monkeypatch.setattr(sys, "prefix", str(running_prefix))
 
     find_extra_reqs.main(
         arguments=[
@@ -268,5 +263,37 @@ def test_main_warns_when_run_from_another_environment(
         ],
     )
 
-    expected_start = f"WARNING: Running from {running_prefix}, "
-    assert capsys.readouterr().err.startswith(expected_start)
+    running_prefix = Path(sys.prefix).resolve()
+    expected_stderr = (
+        f"WARNING: Running from {running_prefix}, but the active "
+        f"virtual environment is {active_prefix}. "
+        "Results describe the environment pip-check-reqs is installed in. "
+        "Install pip-check-reqs in the active virtual environment, and "
+        'run "hash -r" ("rehash" in zsh), to check that environment.\n'
+    )
+    assert capsys.readouterr().err == expected_stderr
+
+
+def test_main_does_not_warn_when_run_from_the_active_environment(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    requirements_file = tmp_path / "requirements.txt"
+    requirements_file.touch()
+
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    (source_dir / "source.py").write_text("import pprint")
+
+    monkeypatch.setenv("VIRTUAL_ENV", sys.prefix)
+
+    find_extra_reqs.main(
+        arguments=[
+            "--requirements-file",
+            str(requirements_file),
+            str(source_dir),
+        ],
+    )
+
+    assert capsys.readouterr().err == ""

--- a/tests/test_find_extra_reqs.py
+++ b/tests/test_find_extra_reqs.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import re
+import sys
 import textwrap
 from typing import TYPE_CHECKING
 
@@ -240,3 +241,32 @@ def test_main_version(capsys: pytest.CaptureFixture[str]) -> None:
         find_extra_reqs.main(arguments=["--version"])
 
     assert capsys.readouterr().out == common.version_info() + "\n"
+
+
+def test_main_warns_when_run_from_another_environment(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    requirements_file = tmp_path / "requirements.txt"
+    requirements_file.touch()
+
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    (source_dir / "source.py").write_text("import pprint")
+
+    active_prefix = tmp_path / "active"
+    running_prefix = tmp_path / "running"
+    monkeypatch.setenv("VIRTUAL_ENV", str(active_prefix))
+    monkeypatch.setattr(sys, "prefix", str(running_prefix))
+
+    find_extra_reqs.main(
+        arguments=[
+            "--requirements-file",
+            str(requirements_file),
+            str(source_dir),
+        ],
+    )
+
+    expected_start = f"WARNING: Running from {running_prefix}, "
+    assert capsys.readouterr().err.startswith(expected_start)

--- a/tests/test_find_missing_reqs.py
+++ b/tests/test_find_missing_reqs.py
@@ -343,9 +343,7 @@ def test_main_warns_when_run_from_another_environment(
     (source_dir / "source.py").write_text("import pprint")
 
     active_prefix = tmp_path / "active"
-    running_prefix = tmp_path / "running"
     monkeypatch.setenv("VIRTUAL_ENV", str(active_prefix))
-    monkeypatch.setattr(sys, "prefix", str(running_prefix))
 
     find_missing_reqs.main(
         arguments=[
@@ -355,5 +353,37 @@ def test_main_warns_when_run_from_another_environment(
         ],
     )
 
-    expected_start = f"WARNING: Running from {running_prefix}, "
-    assert capsys.readouterr().err.startswith(expected_start)
+    running_prefix = Path(sys.prefix).resolve()
+    expected_stderr = (
+        f"WARNING: Running from {running_prefix}, but the active "
+        f"virtual environment is {active_prefix}. "
+        "Results describe the environment pip-check-reqs is installed in. "
+        "Install pip-check-reqs in the active virtual environment, and "
+        'run "hash -r" ("rehash" in zsh), to check that environment.\n'
+    )
+    assert capsys.readouterr().err == expected_stderr
+
+
+def test_main_does_not_warn_when_run_from_the_active_environment(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    requirements_file = tmp_path / "requirements.txt"
+    requirements_file.touch()
+
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    (source_dir / "source.py").write_text("import pprint")
+
+    monkeypatch.setenv("VIRTUAL_ENV", sys.prefix)
+
+    find_missing_reqs.main(
+        arguments=[
+            "--requirements-file",
+            str(requirements_file),
+            str(source_dir),
+        ],
+    )
+
+    assert capsys.readouterr().err == ""

--- a/tests/test_find_missing_reqs.py
+++ b/tests/test_find_missing_reqs.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import re
+import sys
 import textwrap
 from pathlib import Path
 
@@ -327,3 +328,32 @@ def test_main_version(capsys: pytest.CaptureFixture[str]) -> None:
         find_missing_reqs.main(arguments=["--version"])
 
     assert capsys.readouterr().out == common.version_info() + "\n"
+
+
+def test_main_warns_when_run_from_another_environment(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    requirements_file = tmp_path / "requirements.txt"
+    requirements_file.touch()
+
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    (source_dir / "source.py").write_text("import pprint")
+
+    active_prefix = tmp_path / "active"
+    running_prefix = tmp_path / "running"
+    monkeypatch.setenv("VIRTUAL_ENV", str(active_prefix))
+    monkeypatch.setattr(sys, "prefix", str(running_prefix))
+
+    find_missing_reqs.main(
+        arguments=[
+            "--requirements-file",
+            str(requirements_file),
+            str(source_dir),
+        ],
+    )
+
+    expected_start = f"WARNING: Running from {running_prefix}, "
+    assert capsys.readouterr().err.startswith(expected_start)


### PR DESCRIPTION
Closes #83.

A shell caches command paths, so right after `pip install pip-check-reqs` into a new virtual environment the shell can still resolve `pip-missing-reqs` / `pip-extra-reqs` to a command from another environment. Those commands inspect the packages installed alongside themselves, so the results silently describe the wrong environment.

Both commands now compare `sys.prefix` against `VIRTUAL_ENV` and, when they differ, write a warning to stderr naming both prefixes and suggesting `hash -r`. The warning is yellow when stderr is a terminal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive stderr warnings only; no change to requirement scanning logic or exit codes beyond existing behavior.
> 
> **Overview**
> **pip-missing-reqs** and **pip-extra-reqs** now detect when the interpreter running the tool (`sys.prefix`) is not the active virtual environment (`VIRTUAL_ENV`) and print a **stderr warning** before scanning. That covers the case where a shell still resolves the CLI to an install in another env after `pip install`, so results would silently describe the wrong site-packages.
> 
> Shared logic lives in `wrong_environment_warning` / `report_wrong_environment` in `common.py`: no warning if `VIRTUAL_ENV` is unset or matches the running prefix; otherwise the message names both paths, notes that results reflect where **pip-check-reqs** is installed, and suggests installing in the active env plus `hash -r` / `rehash`. Warnings are **yellow on a TTY** stderr.
> 
> CHANGELOG documents the behavior for the next release; unit and CLI tests cover the three cases (no venv, match, mismatch).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d229558adb2e8b737784d75b307272f0e8e7191. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->