### PR TITLE
Do not report an uninstalled requirement as extra

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,11 @@ Release History
 - Both commands now warn when they are run from outside the active virtual
   environment, as the results then describe the environment the command is
   installed in rather than the active one.
+- ``pip-extra-reqs`` no longer reports a requirement which is not installed
+  as an extra requirement. Which modules a requirement provides is only
+  known from the installed distribution, so an uninstalled requirement was
+  reported as extra even when the code imported it. It is now reported as a
+  warning saying that it could not be checked.
 
 3.0.0
 

--- a/README.rst
+++ b/README.rst
@@ -52,6 +52,11 @@ requirements.txt that are then unused in the project::
 This would find anything that is listed in requirements.txt but that is not
 imported by sample.
 
+``pip-extra-reqs`` learns which modules a requirement provides from the
+installed distribution, so it cannot check a requirement which is not
+installed in the environment. It warns about each such requirement rather
+than reporting it as extra.
+
 Sample tox.ini configuration
 ----------------------------
 

--- a/pip_check_reqs/find_extra_reqs.py
+++ b/pip_check_reqs/find_extra_reqs.py
@@ -43,10 +43,12 @@ def find_extra_reqs(
 
     installed_files: dict[Path, str] = {}
     packages_info = common.get_packages_info()
+    installed_names: set[NormalizedName] = set()
 
     for package in packages_info:
         package_name = package.name
         package_location = package.location
+        installed_names.add(canonicalize_name(package_name))
 
         log.debug(
             "installed package: %s (at %s)",
@@ -95,7 +97,26 @@ def find_extra_reqs(
         requirements_filename=requirements_filename,
     )
 
-    return [name for name in explicit if name not in used]
+    extras: list[str] = []
+    for name in explicit:
+        if name in used:
+            continue
+
+        if name not in installed_names:
+            # We know which modules a requirement provides by looking at the
+            # files of the installed distribution, so a requirement which is
+            # not installed looks unused even when the code imports it.
+            # Reporting it would be a false positive, so we say what we could
+            # not check instead.
+            log.warning(
+                "%s is not installed, so we cannot tell whether it is used",
+                name,
+            )
+            continue
+
+        extras.append(name)
+
+    return extras
 
 
 def main(arguments: list[str] | None = None) -> None:

--- a/tests/test_find_extra_reqs.py
+++ b/tests/test_find_extra_reqs.py
@@ -51,11 +51,47 @@ def test_find_extra_reqs(tmp_path: Path) -> None:
         ignore_requirements_function=common.ignorer(ignore_cfg=[]),
         skip_incompatible=False,
     )
-    expected_result = [
-        "not-installed-package-12345",
-        installed_not_imported_required_package.__name__,
-    ]
-    assert sorted(result) == sorted(expected_result)
+    expected_result = [installed_not_imported_required_package.__name__]
+    assert result == expected_result
+
+
+def test_uninstalled_requirement_is_not_extra(
+    *,
+    caplog: pytest.LogCaptureFixture,
+    tmp_path: Path,
+) -> None:
+    """An uninstalled requirement is reported as unchecked, not as extra.
+
+    We tell which modules a requirement provides from the files of the
+    installed distribution, so we cannot tell whether an uninstalled
+    requirement is used, even when the code imports it.
+    """
+    fake_requirements_file = tmp_path / "requirements.txt"
+    fake_requirements_file.write_text("not_installed_package_12345==1\n")
+
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+
+    source_file = source_dir / "source.py"
+    source_file.write_text("import not_installed_package_12345\n")
+
+    caplog.set_level(logging.WARNING)
+
+    result = find_extra_reqs.find_extra_reqs(
+        requirements_filename=fake_requirements_file,
+        paths=[source_dir],
+        ignore_files_function=common.ignorer(ignore_cfg=[]),
+        ignore_modules_function=common.ignorer(ignore_cfg=[]),
+        ignore_requirements_function=common.ignorer(ignore_cfg=[]),
+        skip_incompatible=False,
+    )
+
+    assert not result
+    expected_message = (
+        "not-installed-package-12345 is not installed, so we cannot tell "
+        "whether it is used"
+    )
+    assert [record.message for record in caplog.records] == [expected_message]
 
 
 def test_main_failure(
@@ -63,8 +99,12 @@ def test_main_failure(
     caplog: pytest.LogCaptureFixture,
     tmp_path: Path,
 ) -> None:
+    installed_not_imported_required_package = pytest
+
     requirements_file = tmp_path / "requirements.txt"
-    requirements_file.write_text("extra")
+    requirements_file.write_text(
+        installed_not_imported_required_package.__name__,
+    )
 
     source_dir = tmp_path / "source"
     source_dir.mkdir()
@@ -83,7 +123,11 @@ def test_main_failure(
     assert excinfo.value.code == 1
 
     assert caplog.records[0].message == "Extra requirements:"
-    assert caplog.records[1].message == f"extra in {requirements_file}"
+    expected_message = (
+        f"{installed_not_imported_required_package.__name__} in "
+        f"{requirements_file}"
+    )
+    assert caplog.records[1].message == expected_message
 
 
 def test_main_no_spec(capsys: pytest.CaptureFixture[str]) -> None:


### PR DESCRIPTION
Fixes #81.

`pip-extra-reqs` learns which modules a requirement provides from the files
of the installed distribution. A requirement which is not installed therefore
looked unused, and was reported as extra even when the code imported it.

Such a requirement is now left out of the extras and reported as a warning
saying that it could not be checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is localized to extra-req detection logic with clearer warnings; no auth, security, or data paths involved.
> 
> **Overview**
> **`pip-extra-reqs` no longer treats uninstalled requirements as extras.** Module coverage is inferred from installed distribution files, so a line in `requirements.txt` without a matching install could look unused even when the code imports it.
> 
> The comparison step now tracks **installed** package names (`installed_names`). Requirements that are not used **and** not installed are **omitted** from the extra list and emit a **warning** (`… is not installed, so we cannot tell whether it is used`). Only installed requirements that still do not map to any import remain extras.
> 
> **Docs and tests** document this behavior in `CHANGELOG.rst` and `README.rst`, adjust expectations in `test_find_extra_reqs`, and add `test_uninstalled_requirement_is_not_extra` for the warning path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ec1f86c95f22174a11c7269ad882567adbf50ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->