### PR TITLE
Report an import which is not installed from pip-missing-reqs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,11 @@ Release History
 - Both commands now warn when they are run from outside the active virtual
   environment, as the results then describe the environment the command is
   installed in rather than the active one.
+- ``pip-missing-reqs`` now warns about an import of a module which is not
+  installed, giving the file and line. Such an import was silently ignored,
+  so a package uninstalled by mistake, or an import of the wrong name, gave
+  no output at all. A module which the scanned source provides is not
+  reported, and ``--ignore-module`` silences the warning.
 - ``pip-extra-reqs`` no longer reports a requirement which is not installed
   as an extra requirement. Which modules a requirement provides is only
   known from the installed distribution, so an uninstalled requirement was

--- a/README.rst
+++ b/README.rst
@@ -52,6 +52,13 @@ requirements.txt that are then unused in the project::
 This would find anything that is listed in requirements.txt but that is not
 imported by sample.
 
+``pip-missing-reqs`` learns which requirement provides a module from the
+installed distribution, so an import of a module which is not installed
+cannot be traced to a requirement. It warns about each such import, giving
+the file and line, rather than passing over it. Silence a warning with
+``--ignore-module`` if the import is conditional, or if the module comes
+from a path which you do not give to ``pip-missing-reqs``.
+
 ``pip-extra-reqs`` learns which modules a requirement provides from the
 installed distribution, so it cannot check a requirement which is not
 installed in the environment. It warns about each such requirement rather

--- a/pip_check_reqs/common.py
+++ b/pip_check_reqs/common.py
@@ -67,11 +67,27 @@ class FoundModule:
         self.filename = Path(self.filename).resolve()
 
 
+@dataclass
+class ImportedModules:
+    """The modules which the scanned source imports."""
+
+    found: dict[str, FoundModule]
+    """Modules which we found in the environment, keyed by module name."""
+
+    uninstalled: dict[str, list[tuple[str, int]]]
+    """Top-level modules which are not installed, keyed by module name.
+
+    Each value is the list of ``(filename, line number)`` locations which
+    import the module.
+    """
+
+
 class _ImportVisitor(ast.NodeVisitor):
     def __init__(self, ignore_modules_function: Callable[[str], bool]) -> None:
         super().__init__()
         self._ignore_modules_function = ignore_modules_function
         self._modules: dict[str, FoundModule] = {}
+        self._uninstalled: dict[str, list[tuple[str, int]]] = {}
         self._location: str | None = None
 
     def set_location(self, *, location: str) -> None:
@@ -97,6 +113,7 @@ class _ImportVisitor(ast.NodeVisitor):
             # relative import
             return
         if not self._module_exists(modname=node.module):
+            self._record_uninstalled(modname=node.module, lineno=node.lineno)
             return
         for alias in node.names:
             self._add_module(node.module + "." + alias.name, node.lineno)
@@ -115,6 +132,32 @@ class _ImportVisitor(ast.NodeVisitor):
             modname_parts_progress.append(modname_part)
         return True
 
+    def _record_uninstalled(self, *, modname: str, lineno: int) -> None:
+        """Note an import which we could not resolve to an installed module.
+
+        We only note the import when its top-level module is missing, which
+        is what an uninstalled distribution looks like. A missing sub-module
+        of an installed distribution is a different problem, and the
+        distribution which would provide it is checked already.
+        """
+        top_level_name = modname.split(".", maxsplit=1)[0]
+        if self._ignore_modules_function(top_level_name):
+            return
+
+        try:
+            module_spec = find_spec(name=top_level_name)
+        except ValueError:
+            # The module has no ``__spec__`` attribute, as ``__main__`` does
+            # not, so it is available rather than missing.
+            return
+
+        if module_spec is not None:
+            return
+
+        assert isinstance(self._location, str)
+        locations = self._uninstalled.setdefault(top_level_name, [])
+        locations.append((self._location, lineno))
+
     def _add_module(self, modname: str, lineno: int) -> None:
         if self._ignore_modules_function(modname):
             return
@@ -131,6 +174,7 @@ class _ImportVisitor(ast.NodeVisitor):
 
             if module_spec is None:
                 # The component specified at this point is not installed.
+                self._record_uninstalled(modname=name, lineno=lineno)
                 return
 
             if module_spec.origin is None:
@@ -168,6 +212,9 @@ class _ImportVisitor(ast.NodeVisitor):
 
     def finalise(self) -> dict[str, FoundModule]:
         return self._modules
+
+    def uninstalled(self) -> dict[str, list[tuple[str, int]]]:
+        return self._uninstalled
 
 
 def pyfiles(root: Path) -> Generator[Path, None, None]:
@@ -211,12 +258,36 @@ def log_level(*, debug: bool, verbose: bool) -> int:
     return logging.WARNING
 
 
+def source_module_names(*, paths: Iterable[Path]) -> set[str]:
+    """Return the top-level module names which the scanned source provides.
+
+    A module of the source we scan is not expected to be installed, so we
+    must not report it as uninstalled. We do not import the source, so we
+    take the names from the file system: any file or directory name at or
+    below a path we scan can name a module of the source.
+    """
+    names: set[str] = set()
+    for path in paths:
+        absolute_path = path.absolute()
+        for filename in pyfiles(path):
+            names.add(filename.stem)
+            if absolute_path.is_dir():
+                relative_filename = filename.relative_to(absolute_path)
+                names.update(relative_filename.parts[:-1])
+        names.add(absolute_path.stem)
+    return names
+
+
 def find_imported_modules(
     *,
     paths: Iterable[Path],
     ignore_files_function: Callable[[str], bool],
     ignore_modules_function: Callable[[str], bool],
-) -> dict[str, FoundModule]:
+) -> ImportedModules:
+    # We take the names the source provides before scanning, as an ignored
+    # file still gives a module which the source, and not an installed
+    # distribution, provides.
+    provided_names = source_module_names(paths=paths)
     vis = _ImportVisitor(ignore_modules_function=ignore_modules_function)
     for path in paths:
         for filename in pyfiles(path):
@@ -235,7 +306,13 @@ def find_imported_modules(
                 msg = f"could not parse {filename}:{exc.lineno}: {exc.msg}"
                 raise ValueError(msg) from exc
             vis.visit(tree)
-    return vis.finalise()
+
+    uninstalled = {
+        modname: locations
+        for modname, locations in vis.uninstalled().items()
+        if modname not in provided_names
+    }
+    return ImportedModules(found=vis.finalise(), uninstalled=uninstalled)
 
 
 def find_required_modules(

--- a/pip_check_reqs/find_extra_reqs.py
+++ b/pip_check_reqs/find_extra_reqs.py
@@ -39,7 +39,7 @@ def find_extra_reqs(
         paths=paths,
         ignore_files_function=ignore_files_function,
         ignore_modules_function=ignore_modules_function,
-    )
+    ).found
 
     installed_files: dict[Path, str] = {}
     packages_info = common.get_packages_info()

--- a/pip_check_reqs/find_missing_reqs.py
+++ b/pip_check_reqs/find_missing_reqs.py
@@ -28,11 +28,12 @@ def find_missing_reqs(
 ) -> list[tuple[NormalizedName, list[common.FoundModule]]]:
     # 1. find files used by imports in the code (as best we can without
     #    executing)
-    used_modules = common.find_imported_modules(
+    imported_modules = common.find_imported_modules(
         paths=paths,
         ignore_files_function=ignore_files_function,
         ignore_modules_function=ignore_modules_function,
     )
+    used_modules = imported_modules.found
 
     installed_files: dict[Path, str] = {}
     packages_info = common.get_packages_info()
@@ -92,7 +93,40 @@ def find_missing_reqs(
             requirements_filename=filename,
         )
 
+    _report_uninstalled_imports(
+        uninstalled=imported_modules.uninstalled,
+        explicit=explicit,
+    )
+
     return [(name, used[name]) for name in used if name not in explicit]
+
+
+def _report_uninstalled_imports(
+    *,
+    uninstalled: dict[str, list[tuple[str, int]]],
+    explicit: set[NormalizedName],
+) -> None:
+    """Warn about imports of modules which are not installed.
+
+    We tell which distribution provides a module from the files of the
+    installed distribution, so we cannot tell whether a module which is not
+    installed is required. Such an import was silently ignored, which hid
+    both an import of the wrong name and a package uninstalled by mistake.
+    """
+    for modname, locations in uninstalled.items():
+        if canonicalize_name(modname) in explicit:
+            # The requirement is listed but not installed, so there is
+            # nothing to report: the import is accounted for.
+            continue
+
+        for filename, lineno in locations:
+            log.warning(
+                "%s:%s module=%s is not installed, so we cannot tell which "
+                "requirement provides it",
+                filename,
+                lineno,
+                modname,
+            )
 
 
 def main(arguments: list[str] | None = None) -> None:

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -117,7 +117,7 @@ def test_find_imported_modules_simple(
         paths=[tmp_path],
         ignore_files_function=common.ignorer(ignore_cfg=[]),
         ignore_modules_function=common.ignorer(ignore_cfg=[]),
-    )
+    ).found
 
     assert set(result.keys()) == expected_module_names
     for value in result.values():
@@ -156,7 +156,7 @@ def test_find_imported_modules_frozen(
         paths=[tmp_path],
         ignore_files_function=common.ignorer(ignore_cfg=[]),
         ignore_modules_function=common.ignorer(ignore_cfg=[]),
-    )
+    ).found
 
     assert set(result.keys()) == set()
 
@@ -186,7 +186,7 @@ def test_find_imported_modules_main(
         paths=[tmp_path],
         ignore_files_function=common.ignorer(ignore_cfg=[]),
         ignore_modules_function=common.ignorer(ignore_cfg=[]),
-    )
+    ).found
 
     assert set(result.keys()) == set()
 
@@ -214,7 +214,7 @@ def test_find_imported_modules_no_spec(tmp_path: Path) -> None:
             paths=[tmp_path],
             ignore_files_function=common.ignorer(ignore_cfg=[]),
             ignore_modules_function=common.ignorer(ignore_cfg=[]),
-        )
+        ).found
     finally:
         del sys.modules[name]
     assert set(result.keys()) == set()
@@ -261,7 +261,7 @@ def test_find_imported_modules_period(tmp_path: Path) -> None:
         paths=[tmp_path],
         ignore_files_function=common.ignorer(ignore_cfg=[]),
         ignore_modules_function=common.ignorer(ignore_cfg=[]),
-    )
+    ).found
 
     assert set(result.keys()) == {"ruamel.yaml"}
 
@@ -288,7 +288,7 @@ def test_find_imported_modules_missing_from_submodule(
         paths=[source_dir],
         ignore_files_function=common.ignorer(ignore_cfg=[]),
         ignore_modules_function=common.ignorer(ignore_cfg=[]),
-    )
+    ).found
 
     assert not result
 
@@ -357,7 +357,7 @@ def test_find_imported_modules_advanced(
         paths=[root],
         ignore_files_function=ignore_files,
         ignore_modules_function=ignore_mods,
-    )
+    ).found
     assert set(result) == set(expect)
     absolute_locations = result["ast"].locations
     relative_locations = [
@@ -368,6 +368,163 @@ def test_find_imported_modules_advanced(
 
     if ignore_ham:
         assert caplog.records[0].message == f"ignoring: {ham}"
+
+
+def test_find_imported_modules_uninstalled(tmp_path: Path) -> None:
+    """An import of a module which is not installed is reported."""
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    source_file = source_dir / "spam.py"
+    name = "a" + uuid.uuid4().hex
+    source_file.write_text(
+        data=textwrap.dedent(
+            text=f"""\
+            import re
+            import {name}
+            from {name}.ham import eggs
+            """,
+        ),
+    )
+
+    result = common.find_imported_modules(
+        paths=[source_dir],
+        ignore_files_function=common.ignorer(ignore_cfg=[]),
+        ignore_modules_function=common.ignorer(ignore_cfg=[]),
+    )
+
+    assert set(result.found) == {"re"}
+    assert result.uninstalled == {
+        name: [(str(source_file), 2), (str(source_file), 3)],
+    }
+
+
+@pytest.mark.parametrize(
+    "ignore_glob",
+    [
+        pytest.param("{name}", id="Top-level module name"),
+        pytest.param("{name}*", id="Glob"),
+    ],
+)
+def test_find_imported_modules_uninstalled_ignored(
+    *,
+    ignore_glob: str,
+    tmp_path: Path,
+) -> None:
+    """An ignored module which is not installed is not reported."""
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    name = "a" + uuid.uuid4().hex
+    (source_dir / "spam.py").write_text(data=f"import {name}.ham\n")
+
+    result = common.find_imported_modules(
+        paths=[source_dir],
+        ignore_files_function=common.ignorer(ignore_cfg=[]),
+        ignore_modules_function=common.ignorer(
+            ignore_cfg=[ignore_glob.format(name=name)],
+        ),
+    )
+
+    assert not result.uninstalled
+
+
+def test_find_imported_modules_uninstalled_no_spec(tmp_path: Path) -> None:
+    """A module without a ``__spec__`` is available, so is not reported.
+
+    See ``test_find_imported_modules_no_spec`` for how such a module comes
+    about.
+    """
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    name = "a" + uuid.uuid4().hex
+    (source_dir / "spam.py").write_text(data=f"from {name}.ham import eggs\n")
+    module = types.ModuleType(name=name)
+    module.__spec__ = None
+    sys.modules[name] = module
+
+    try:
+        result = common.find_imported_modules(
+            paths=[source_dir],
+            ignore_files_function=common.ignorer(ignore_cfg=[]),
+            ignore_modules_function=common.ignorer(ignore_cfg=[]),
+        )
+    finally:
+        del sys.modules[name]
+
+    assert not result.uninstalled
+
+
+def test_find_imported_modules_uninstalled_submodule(tmp_path: Path) -> None:
+    """A missing sub-module of an installed package is not reported.
+
+    The distribution which would provide the sub-module is installed, so
+    there is no requirement which we cannot check.
+    """
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    (source_dir / "spam.py").write_text(
+        data=textwrap.dedent(
+            text="""\
+            import pytest.missing
+            from pytest.missing import attribute
+            """,
+        ),
+    )
+
+    result = common.find_imported_modules(
+        paths=[source_dir],
+        ignore_files_function=common.ignorer(ignore_cfg=[]),
+        ignore_modules_function=common.ignorer(ignore_cfg=[]),
+    )
+
+    assert not result.uninstalled
+
+
+@pytest.mark.parametrize(
+    "statement",
+    [
+        pytest.param("import spam", id="Module in the source"),
+        pytest.param("import ham", id="Package in the source"),
+        pytest.param("from ham.eggs import scrambled", id="Source submodule"),
+        pytest.param("import source", id="Directory we scan"),
+        pytest.param("import ignored", id="Ignored file in the source"),
+    ],
+)
+def test_find_imported_modules_source_module(
+    *,
+    statement: str,
+    tmp_path: Path,
+) -> None:
+    """A module which the scanned source provides is not reported.
+
+    Such a module is not expected to be installed, so reporting it would be
+    a false positive.
+    """
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    (source_dir / "spam.py").write_text(data=statement)
+    (source_dir / "ignored.py").touch()
+    package_dir = source_dir / "ham"
+    package_dir.mkdir()
+    (package_dir / "__init__.py").touch()
+    (package_dir / "eggs.py").touch()
+
+    result = common.find_imported_modules(
+        paths=[source_dir],
+        ignore_files_function=common.ignorer(ignore_cfg=["*ignored.py"]),
+        ignore_modules_function=common.ignorer(ignore_cfg=[]),
+    )
+
+    assert not result.uninstalled
+
+
+def test_source_module_names_file(tmp_path: Path) -> None:
+    """A single source file gives its own module name."""
+    source_file = tmp_path / "spam.py"
+    source_file.touch()
+
+    result = common.source_module_names(paths=[source_file])
+
+    assert result == {"spam"}
 
 
 @pytest.mark.parametrize(

--- a/tests/test_find_missing_reqs.py
+++ b/tests/test_find_missing_reqs.py
@@ -66,6 +66,135 @@ def test_find_missing_reqs(tmp_path: Path) -> None:
     assert result == expected_result
 
 
+def test_uninstalled_import_is_reported(
+    *,
+    caplog: pytest.LogCaptureFixture,
+    tmp_path: Path,
+) -> None:
+    """An import of a module which is not installed is reported.
+
+    We know which requirement provides a module from the files of the
+    installed distribution, so we cannot tell whether such an import is
+    required, and we say so rather than passing it over.
+    """
+    fake_requirements_file = tmp_path / "requirements.txt"
+    fake_requirements_file.write_text("pytest\n")
+
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+
+    source_file = source_dir / "source.py"
+    source_file.write_text("import not_installed_package_12345\n")
+
+    caplog.set_level(logging.WARNING)
+
+    result = find_missing_reqs.find_missing_reqs(
+        requirements_filename=fake_requirements_file,
+        paths=[source_dir],
+        ignore_files_function=common.ignorer(ignore_cfg=[]),
+        ignore_modules_function=common.ignorer(ignore_cfg=[]),
+    )
+
+    assert not result
+    expected_message = (
+        f"{source_file}:1 module=not_installed_package_12345 is not "
+        "installed, so we cannot tell which requirement provides it"
+    )
+    assert [record.message for record in caplog.records] == [expected_message]
+
+
+def test_uninstalled_import_of_requirement_is_not_reported(
+    *,
+    caplog: pytest.LogCaptureFixture,
+    tmp_path: Path,
+) -> None:
+    """An import of a listed but uninstalled requirement is not reported.
+
+    The requirement is in the requirements file, so nothing is missing.
+    """
+    fake_requirements_file = tmp_path / "requirements.txt"
+    fake_requirements_file.write_text("Not-Installed-Package-12345==1\n")
+
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    (source_dir / "source.py").write_text("import not_installed_package_12345")
+
+    caplog.set_level(logging.WARNING)
+
+    result = find_missing_reqs.find_missing_reqs(
+        requirements_filename=fake_requirements_file,
+        paths=[source_dir],
+        ignore_files_function=common.ignorer(ignore_cfg=[]),
+        ignore_modules_function=common.ignorer(ignore_cfg=[]),
+    )
+
+    assert not result
+    assert not caplog.records
+
+
+def test_main_uninstalled_import_does_not_fail(
+    *,
+    caplog: pytest.LogCaptureFixture,
+    tmp_path: Path,
+) -> None:
+    """An uninstalled import is a warning rather than a failure.
+
+    An import which we cannot resolve is not always a mistake, as a module
+    of the source may be given by a path we do not scan, so we do not fail
+    the run for it.
+    """
+    requirements_file = tmp_path / "requirements.txt"
+    requirements_file.touch()
+
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    source_file = source_dir / "source.py"
+    source_file.write_text("import not_installed_package_12345\n")
+
+    caplog.set_level(logging.WARNING)
+
+    find_missing_reqs.main(
+        arguments=[
+            "--requirements",
+            str(requirements_file),
+            str(source_dir),
+        ],
+    )
+
+    expected_message = (
+        f"{source_file}:1 module=not_installed_package_12345 is not "
+        "installed, so we cannot tell which requirement provides it"
+    )
+    assert [record.message for record in caplog.records] == [expected_message]
+
+
+def test_main_ignore_module_silences_uninstalled_import(
+    *,
+    caplog: pytest.LogCaptureFixture,
+    tmp_path: Path,
+) -> None:
+    requirements_file = tmp_path / "requirements.txt"
+    requirements_file.touch()
+
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    (source_dir / "source.py").write_text("import not_installed_package_12345")
+
+    caplog.set_level(logging.WARNING)
+
+    find_missing_reqs.main(
+        arguments=[
+            "--requirements",
+            str(requirements_file),
+            "--ignore-module",
+            "not_installed_package_12345",
+            str(source_dir),
+        ],
+    )
+
+    assert not caplog.records
+
+
 def test_main_multiple_requirements_files(
     *,
     caplog: pytest.LogCaptureFixture,


### PR DESCRIPTION
Fixes #80.

`pip-missing-reqs` learns which requirement provides a module from the files of the installed distribution, so an import of a module which is not installed could not be traced to a requirement and was silently ignored, meaning a package uninstalled by mistake or an import of the wrong name gave no output at all. Such an import is now reported as a warning giving the file and line, while the exit code is unchanged.

To avoid false positives, a module which the scanned source itself provides is not reported (names are taken from the file system), nor is a module named by a requirement in the requirements file, nor a missing sub-module of an installed distribution; `--ignore-module` silences the warning.

`common.find_imported_modules` now returns an `ImportedModules` dataclass of the modules it found and the ones which are not installed, and the README and CHANGELOG describe the new behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI behavior change is additive warnings only; exit codes unchanged. Logic is covered by extensive new tests.
> 
> **Overview**
> **`pip-missing-reqs`** now **warns** when source imports a top-level module that is not installed (file and line), instead of ignoring it silently. Warnings do not change the exit code; **`--ignore-module`** still suppresses them.
> 
> Import scanning in **`common`** now returns an **`ImportedModules`** dataclass (`found` + `uninstalled`) rather than only resolved modules. The AST visitor records missing top-level modules via **`_record_uninstalled`**, and **`source_module_names`** drops false positives for modules defined by the scanned tree (including ignored files). Imports already listed in requirements files are not warned.
> 
> **`pip-extra-reqs`** is updated to use **`.found`** only. README and CHANGELOG document the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 245738423bd711dedbe817016fe45ab3435b357b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->