### PR TITLE
Apply --ignore-module to the dotted path of an uninstalled import

### DIFF
--- a/pip_check_reqs/common.py
+++ b/pip_check_reqs/common.py
@@ -141,7 +141,12 @@ class _ImportVisitor(ast.NodeVisitor):
         distribution which would provide it is checked already.
         """
         top_level_name = modname.split(".", maxsplit=1)[0]
-        if self._ignore_modules_function(top_level_name):
+        # An ignore glob may name either the dotted import path, as it may
+        # for an installed module, or just the top-level module which we
+        # report.
+        if self._ignore_modules_function(modname) or (
+            self._ignore_modules_function(top_level_name)
+        ):
             return
 
         try:

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -399,22 +399,31 @@ def test_find_imported_modules_uninstalled(tmp_path: Path) -> None:
 
 
 @pytest.mark.parametrize(
+    "statement",
+    [
+        pytest.param("import {name}.ham\n", id="Import"),
+        pytest.param("from {name}.ham import eggs\n", id="ImportFrom"),
+    ],
+)
+@pytest.mark.parametrize(
     "ignore_glob",
     [
         pytest.param("{name}", id="Top-level module name"),
         pytest.param("{name}*", id="Glob"),
+        pytest.param("{name}.ham", id="Dotted import path"),
     ],
 )
 def test_find_imported_modules_uninstalled_ignored(
     *,
     ignore_glob: str,
+    statement: str,
     tmp_path: Path,
 ) -> None:
     """An ignored module which is not installed is not reported."""
     source_dir = tmp_path / "source"
     source_dir.mkdir()
     name = "a" + uuid.uuid4().hex
-    (source_dir / "spam.py").write_text(data=f"import {name}.ham\n")
+    (source_dir / "spam.py").write_text(data=statement.format(name=name))
 
     result = common.find_imported_modules(
         paths=[source_dir],
@@ -665,8 +674,10 @@ def test_no_wrong_environment_warning_from_active_virtualenv(
 
 
 def test_wrong_environment_warning(tmp_path: Path) -> None:
-    active_prefix = tmp_path / "active"
-    running_prefix = tmp_path / "running"
+    # We resolve the paths as the warning shows resolved paths, and a
+    # temporary directory is reached through a symbolic link on some hosts.
+    active_prefix = (tmp_path / "active").resolve()
+    running_prefix = (tmp_path / "running").resolve()
 
     warning = common.wrong_environment_warning(
         running_prefix=running_prefix,
@@ -685,8 +696,8 @@ def test_wrong_environment_warning(tmp_path: Path) -> None:
 
 
 def test_wrong_environment_warning_in_color(tmp_path: Path) -> None:
-    active_prefix = tmp_path / "active"
-    running_prefix = tmp_path / "running"
+    active_prefix = (tmp_path / "active").resolve()
+    running_prefix = (tmp_path / "running").resolve()
 
     warning = common.wrong_environment_warning(
         running_prefix=running_prefix,

--- a/tests/test_find_extra_reqs.py
+++ b/tests/test_find_extra_reqs.py
@@ -296,7 +296,9 @@ def test_main_warns_when_run_from_another_environment(
     source_dir.mkdir()
     (source_dir / "source.py").write_text("import pprint")
 
-    active_prefix = tmp_path / "active"
+    # We resolve the path as the warning shows resolved paths, and a
+    # temporary directory is reached through a symbolic link on some hosts.
+    active_prefix = (tmp_path / "active").resolve()
     monkeypatch.setenv("VIRTUAL_ENV", str(active_prefix))
 
     find_extra_reqs.main(

--- a/tests/test_find_missing_reqs.py
+++ b/tests/test_find_missing_reqs.py
@@ -471,7 +471,9 @@ def test_main_warns_when_run_from_another_environment(
     source_dir.mkdir()
     (source_dir / "source.py").write_text("import pprint")
 
-    active_prefix = tmp_path / "active"
+    # We resolve the path as the warning shows resolved paths, and a
+    # temporary directory is reached through a symbolic link on some hosts.
+    active_prefix = (tmp_path / "active").resolve()
     monkeypatch.setenv("VIRTUAL_ENV", str(active_prefix))
 
     find_missing_reqs.main(


### PR DESCRIPTION
`--ignore-module` was matched against the full dotted import path for an installed module, but only against the top-level name when reporting an import which is not installed, so a glob such as `foo.ham` silenced `import foo.ham` but not `from foo.ham import eggs`. Both forms now match against the dotted path as well as the top-level name, and the ignore test is parametrized over both import statement forms.

The tests for the wrong environment warning also built their expected text from unresolved `tmp_path` values while the warning shows resolved paths, so they would fail on a host where the temporary directory is reached through a symbolic link; they now resolve the paths.

Both issues were raised as review comments on #599 and #597 after those pull requests merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavior fix in import-ignore logic plus test hardening; no auth, data, or security surface.
> 
> **Overview**
> **`--ignore-module` for missing packages** now checks ignore globs against the **full dotted import path** as well as the top-level module name when recording uninstalled imports. That aligns uninstalled handling with installed imports (e.g. `foo.ham` can silence `from foo.ham import eggs`, not only `import foo.ham`).
> 
> Tests cover both `import` and `from … import` forms and a `{name}.ham` ignore glob. **Wrong-environment warning** tests and CLI integration tests now **`.resolve()`** temporary prefix paths so expected warning text matches production output on hosts where `tmp_path` is reached via a symlink.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4deecbcd9864d93807e3db9e72883c41fb3a57e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->