### PR TITLE
Do not report a soft dependency as an uninstalled import

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,6 +28,10 @@ Release History
   so a package uninstalled by mistake, or an import of the wrong name, gave
   no output at all. A module which the scanned source provides is not
   reported, and ``--ignore-module`` silences the warning.
+- ``pip-missing-reqs`` no longer warns about an import which is not
+  installed when it is made in a ``try`` block which catches
+  ``ImportError``. Such an import is a soft dependency which the code
+  tolerates being absent.
 - ``pip-extra-reqs`` no longer reports a requirement which is not installed
   as an extra requirement. Which modules a requirement provides is only
   known from the installed distribution, so an uninstalled requirement was

--- a/README.rst
+++ b/README.rst
@@ -59,6 +59,16 @@ the file and line, rather than passing over it. Silence a warning with
 ``--ignore-module`` if the import is conditional, or if the module comes
 from a path which you do not give to ``pip-missing-reqs``.
 
+An import in a ``try`` block which catches ``ImportError`` is a soft
+dependency: the code runs whether or not the module is installed.
+``pip-missing-reqs`` does not warn about such an import when the module is
+not installed::
+
+    try:
+        import Levenshtein
+    except ImportError:
+        Levenshtein = None
+
 ``pip-extra-reqs`` learns which modules a requirement provides from the
 installed distribution, so it cannot check a requirement which is not
 installed in the environment. It warns about each such requirement rather

--- a/pip_check_reqs/common.py
+++ b/pip_check_reqs/common.py
@@ -82,6 +82,36 @@ class ImportedModules:
     """
 
 
+_IMPORT_ERROR_NAMES = frozenset({"ImportError", "ModuleNotFoundError"})
+
+
+def _catches_import_error(*, handler: ast.ExceptHandler) -> bool:
+    """Whether an ``except`` clause catches an import which is not installed.
+
+    A bare ``except`` catches everything, so it counts.
+    """
+    if handler.type is None:
+        return True
+
+    caught = (
+        handler.type.elts
+        if isinstance(handler.type, ast.Tuple)
+        else [handler.type]
+    )
+    for exception in caught:
+        if isinstance(exception, ast.Name):
+            name = exception.id
+        elif isinstance(exception, ast.Attribute):
+            # An exception may be given by a dotted path, as
+            # ``builtins.ImportError`` is.
+            name = exception.attr
+        else:
+            continue
+        if name in _IMPORT_ERROR_NAMES:
+            return True
+    return False
+
+
 class _ImportVisitor(ast.NodeVisitor):
     def __init__(self, ignore_modules_function: Callable[[str], bool]) -> None:
         super().__init__()
@@ -89,6 +119,7 @@ class _ImportVisitor(ast.NodeVisitor):
         self._modules: dict[str, FoundModule] = {}
         self._uninstalled: dict[str, list[tuple[str, int]]] = {}
         self._location: str | None = None
+        self._optional_import_depth = 0
 
     def set_location(self, *, location: str) -> None:
         self._location = location
@@ -118,6 +149,36 @@ class _ImportVisitor(ast.NodeVisitor):
         for alias in node.names:
             self._add_module(node.module + "." + alias.name, node.lineno)
 
+    # Ignore the name error as we are overriding the method.
+    def visit_Try(  # pylint: disable=invalid-name
+        self,
+        node: ast.Try,
+    ) -> None:
+        """Visit a ``try`` statement, noting imports it makes optional.
+
+        A soft dependency is imported in a ``try`` block which catches
+        ``ImportError``, so the code runs whether or not it is installed.
+        Such an import is deliberately optional, so we do not report it as
+        an import we could not resolve.
+        """
+        optional = any(
+            _catches_import_error(handler=handler) for handler in node.handlers
+        )
+        self._optional_import_depth += int(optional)
+        for statement in node.body:
+            self.visit(statement)
+        self._optional_import_depth -= int(optional)
+
+        # An import in a handler, in ``else`` or in ``finally`` is not
+        # guarded by this ``try``, so we treat it as any other import.
+        unguarded: list[ast.AST] = [
+            *node.handlers,
+            *node.orelse,
+            *node.finalbody,
+        ]
+        for node_to_visit in unguarded:
+            self.visit(node_to_visit)
+
     @staticmethod
     def _module_exists(*, modname: str) -> bool:
         modname_parts_progress: list[str] = []
@@ -140,6 +201,11 @@ class _ImportVisitor(ast.NodeVisitor):
         of an installed distribution is a different problem, and the
         distribution which would provide it is checked already.
         """
+        if self._optional_import_depth:
+            # The import is a soft dependency, so the code tolerates the
+            # module not being installed and there is nothing to report.
+            return
+
         top_level_name = modname.split(".", maxsplit=1)[0]
         # An ignore glob may name either the dotted import path, as it may
         # for an installed module, or just the top-level module which we

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -489,6 +489,164 @@ def test_find_imported_modules_uninstalled_submodule(tmp_path: Path) -> None:
 
 
 @pytest.mark.parametrize(
+    "handler",
+    [
+        pytest.param("except ImportError:", id="ImportError"),
+        pytest.param("except ModuleNotFoundError:", id="ModuleNotFoundError"),
+        pytest.param("except builtins.ImportError:", id="Dotted path"),
+        pytest.param("except (ValueError, ImportError):", id="Tuple"),
+        pytest.param("except (*errors, ImportError):", id="Tuple with a star"),
+        pytest.param("except:  # noqa: E722", id="Bare except"),
+    ],
+)
+@pytest.mark.parametrize(
+    "statement",
+    [
+        pytest.param("import {name}", id="Import"),
+        pytest.param("from {name} import ham", id="ImportFrom"),
+    ],
+)
+def test_find_imported_modules_uninstalled_optional(
+    *,
+    handler: str,
+    statement: str,
+    tmp_path: Path,
+) -> None:
+    """An import which the source tolerates failing is not reported.
+
+    A soft dependency is imported in a ``try`` block which catches
+    ``ImportError``, so the code runs whether or not it is installed.
+    """
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    name = "a" + uuid.uuid4().hex
+    (source_dir / "spam.py").write_text(
+        data=textwrap.dedent(
+            text="""\
+            try:
+                {statement}
+            {handler}
+                pass
+            """,
+        ).format(statement=statement.format(name=name), handler=handler),
+    )
+
+    result = common.find_imported_modules(
+        paths=[source_dir],
+        ignore_files_function=common.ignorer(ignore_cfg=[]),
+        ignore_modules_function=common.ignorer(ignore_cfg=[]),
+    )
+
+    assert not result.uninstalled
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        pytest.param(
+            """\
+            try:
+                {statement}
+            except ValueError:
+                pass
+            """,
+            id="Handler which does not catch ImportError",
+        ),
+        pytest.param(
+            """\
+            try:
+                pass
+            except ImportError:
+                {statement}
+            """,
+            id="Import in the handler",
+        ),
+        pytest.param(
+            """\
+            try:
+                pass
+            except ImportError:
+                pass
+            else:
+                {statement}
+            """,
+            id="Import in the else block",
+        ),
+        pytest.param(
+            """\
+            try:
+                pass
+            except ImportError:
+                pass
+            finally:
+                {statement}
+            """,
+            id="Import in the finally block",
+        ),
+        pytest.param(
+            """\
+            try:
+                pass
+            except ImportError:
+                pass
+            {statement}
+            """,
+            id="Import after the try statement",
+        ),
+    ],
+)
+def test_find_imported_modules_uninstalled_not_optional(
+    *,
+    source: str,
+    tmp_path: Path,
+) -> None:
+    """An import which the ``try`` does not guard is still reported."""
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    source_file = source_dir / "spam.py"
+    name = "a" + uuid.uuid4().hex
+    source_file.write_text(
+        data=textwrap.dedent(text=source).format(statement=f"import {name}"),
+    )
+
+    result = common.find_imported_modules(
+        paths=[source_dir],
+        ignore_files_function=common.ignorer(ignore_cfg=[]),
+        ignore_modules_function=common.ignorer(ignore_cfg=[]),
+    )
+
+    assert set(result.uninstalled) == {name}
+
+
+def test_find_imported_modules_optional_installed(tmp_path: Path) -> None:
+    """An optional import of an installed module is still a use of it.
+
+    A soft dependency which is installed and listed in the requirements is
+    used, so ``pip-extra-reqs`` must not report it as extra.
+    """
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    (source_dir / "spam.py").write_text(
+        data=textwrap.dedent(
+            text="""\
+            try:
+                import pytest
+            except ImportError:
+                pass
+            """,
+        ),
+    )
+
+    result = common.find_imported_modules(
+        paths=[source_dir],
+        ignore_files_function=common.ignorer(ignore_cfg=[]),
+        ignore_modules_function=common.ignorer(ignore_cfg=[]),
+    )
+
+    assert set(result.found) == {"pytest"}
+
+
+@pytest.mark.parametrize(
     "statement",
     [
         pytest.param("import spam", id="Module in the source"),


### PR DESCRIPTION
Closes #375.

An import in a `try` block which catches `ImportError` is a soft dependency: the code runs whether or not the module is installed. `pip-missing-reqs` warned that it could not tell which requirement provides such a module, which is a false positive.

```python
try:
    import Levenshtein
except ImportError:
    IS_SPEEDUP = False
```

A handler counts as guarding the import when it catches `ImportError` or `ModuleNotFoundError`, by plain or dotted name, alone or in a tuple, and when it is a bare `except`. Imports in a handler, in `else`, in `finally`, or after the `try` statement are not guarded, and an optional import of a module which is installed is still recorded as a use of it, so `pip-extra-reqs` does not start reporting soft dependencies as extra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to static import analysis with broad test coverage; no auth, I/O, or requirement-resolution logic beyond skipping optional uninstalled imports.
> 
> **Overview**
> **`pip-missing-reqs` no longer warns** when an uninstalled module is imported inside a `try` whose handlers catch `ImportError` or `ModuleNotFoundError` (including dotted names, tuples, and bare `except`).
> 
> Import scanning in `common.py` now walks `try` AST nodes: imports in the `try` body are treated as optional only when such a handler exists; imports in `except`/`else`/`finally` or after the block are still reported. Optional missing imports are skipped in `_record_uninstalled`; **installed** optional imports remain in `found` so **`pip-extra-reqs` behavior is unchanged**.
> 
> CHANGELOG and README document the soft-dependency pattern; tests cover guarded vs unguarded cases and optional installed imports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea5d8260689f28ae3090306ec7d7a2cc6c193250. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->