### PR TITLE
Recognise requirements installed in editable mode

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,6 +32,11 @@ Release History
   installed when it is made in a ``try`` block which catches
   ``ImportError``. Such an import is a soft dependency which the code
   tolerates being absent.
+- A requirement installed in editable mode, with ``pip install -e``, is now
+  matched to the modules it provides. ``pip-extra-reqs`` reported such a
+  requirement as extra even when the code imported it, and
+  ``pip-missing-reqs`` did not report an import of one which was not
+  required.
 - ``pip-extra-reqs`` no longer reports a requirement which is not installed
   as an extra requirement. Which modules a requirement provides is only
   known from the installed distribution, so an uninstalled requirement was

--- a/README.rst
+++ b/README.rst
@@ -74,6 +74,14 @@ installed distribution, so it cannot check a requirement which is not
 installed in the environment. It warns about each such requirement rather
 than reporting it as extra.
 
+A requirement installed in editable mode, with ``pip install -e``, imports
+its modules from the directory it is installed from rather than from a copy
+in ``site-packages``. Both commands read that directory from the install, so
+an editable requirement is checked as any other requirement is. The source
+you give to the commands is the project being checked rather than a
+requirement of it, so a module of that source is not treated as a
+requirement even when the project itself is installed in editable mode.
+
 Sample tox.ini configuration
 ----------------------------
 

--- a/pip_check_reqs/common.py
+++ b/pip_check_reqs/common.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import ast
+import collections
 import fnmatch
 import importlib.metadata
+import json
 import logging
 import os
 import sys
@@ -23,6 +25,7 @@ from pip._internal.commands.show import (
 from pip._internal.network.session import PipSession
 from pip._internal.req.constructors import install_req_from_line
 from pip._internal.req.req_file import ParsedRequirement, parse_requirements
+from pip._internal.utils.urls import url_to_path
 
 from . import __version__
 
@@ -254,25 +257,24 @@ class _ImportVisitor(ast.NodeVisitor):
 
             modpath = module_spec.origin
 
-            if modpath == "frozen":
+            if modpath in ("frozen", "built-in"):
                 # Frozen modules are modules written in Python whose compiled
                 # byte-code object is incorporated into a custom-built Python
                 # interpreter by Python's freeze utility.
+                # A built-in module, such as ``sys``, is compiled into the
+                # interpreter.
+                # Neither has an origin which names a file, so there is no
+                # file to attribute to a distribution.
                 continue
 
             modpath_path = Path(modpath)
             modname = module_spec.name
 
             if modname not in self._modules:
-                if modpath_path.is_file():
-                    if modpath_path.name == "__init__.py":
-                        modpath_path = modpath_path.parent
-                    else:
-                        # We have this empty "else" so that we are
-                        # not tempted to combine the "is file" and "is
-                        # __init__" checks, and to make sure we have coverage
-                        # for this case.
-                        pass
+                if modpath_path.name == "__init__.py":
+                    # The origin of a package is its ``__init__.py``, and we
+                    # want the directory of the package itself.
+                    modpath_path = modpath_path.parent
                 self._modules[modname] = FoundModule(
                     modname=modname,
                     filename=modpath_path,
@@ -384,6 +386,124 @@ def find_imported_modules(
         if modname not in provided_names
     }
     return ImportedModules(found=vis.finalise(), uninstalled=uninstalled)
+
+
+def installed_distribution_names() -> set[NormalizedName]:
+    """Return the name of each distribution installed in the environment."""
+    return {canonicalize_name(package.name) for package in get_packages_info()}
+
+
+def _installed_files() -> dict[Path, str]:
+    """Map each file of an installed distribution to the distribution name."""
+    installed_files: dict[Path, str] = {}
+    for package in get_packages_info():
+        log.debug(
+            "installed package: %s (at %s)",
+            package.name,
+            package.location,
+        )
+        for item in package.files or []:
+            path = cached_resolve_path(path=Path(package.location) / item)
+            installed_files[path] = package.name
+            containing_package_path = package_path(path=path)
+            if containing_package_path:
+                # we've seen a package file so add the bare package directory
+                # to the installed list as well as we might want to look up
+                # a package by its directory path later
+                installed_files[containing_package_path] = package.name
+    return installed_files
+
+
+@cache
+def editable_source_directories() -> dict[Path, str]:
+    """Map the source directory of each editable install to its distribution.
+
+    An editable install records the files of the wheel which pip installed,
+    which for an editable install are an import hook and not the modules of
+    the distribution. The modules are imported from the project directory
+    instead, so the files of the distribution do not tell us which modules it
+    provides. The project directory is recorded in ``direct_url.json``, as
+    described by PEP 610, so we take it from there.
+    """
+    directories: dict[Path, str] = {}
+    for distribution in importlib.metadata.distributions():
+        direct_url_text = distribution.read_text("direct_url.json")
+        if direct_url_text is None:
+            continue
+
+        direct_url = json.loads(direct_url_text)
+        directory_info = direct_url.get("dir_info", {})
+        if not directory_info.get("editable", False):
+            continue
+
+        # An editable install is always of a local directory, so the URL is
+        # a ``file`` URL.
+        directory = cached_resolve_path(
+            path=Path(url_to_path(direct_url["url"])),
+        )
+        directories[directory] = distribution.metadata["Name"]
+
+    return directories
+
+
+def _editable_distribution_name(
+    *,
+    filename: Path,
+    scanned_paths: Iterable[Path],
+) -> str | None:
+    """Return the editable distribution which provides ``filename``.
+
+    Return ``None`` when no editable install provides the file.
+
+    A file of the source we scan is not a file of a dependency even when the
+    source is installed as editable, as it is the project being checked and
+    not a distribution it requires.
+    """
+    if any(
+        filename == scanned_path or filename.is_relative_to(scanned_path)
+        for scanned_path in scanned_paths
+    ):
+        return None
+
+    for directory, name in editable_source_directories().items():
+        if filename.is_relative_to(directory):
+            return name
+    return None
+
+
+def used_packages(
+    *,
+    used_modules: dict[str, FoundModule],
+    paths: Iterable[Path],
+) -> dict[NormalizedName, list[FoundModule]]:
+    """Map each distribution used by the scanned source to its uses."""
+    installed_files = _installed_files()
+    scanned_paths = [cached_resolve_path(path=path) for path in paths]
+
+    used: collections.defaultdict[NormalizedName, list[FoundModule]] = (
+        collections.defaultdict(list)
+    )
+    for modname, info in used_modules.items():
+        # probably standard library if it's not in the files list
+        name = installed_files.get(info.filename)
+        if name is None:
+            name = _editable_distribution_name(
+                filename=info.filename,
+                scanned_paths=scanned_paths,
+            )
+
+        if name is None:
+            log.debug(
+                "used module: %s (from file %s, assuming stdlib or local)",
+                modname,
+                info.filename,
+            )
+            continue
+
+        log.debug("used module: %s (from package %s)", modname, name)
+        used[canonicalize_name(name)].append(info)
+
+    return used
 
 
 def find_required_modules(

--- a/pip_check_reqs/find_extra_reqs.py
+++ b/pip_check_reqs/find_extra_reqs.py
@@ -3,13 +3,10 @@
 from __future__ import annotations
 
 import argparse
-import collections
 import logging
 import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
-
-from packaging.utils import NormalizedName, canonicalize_name
 
 from pip_check_reqs import common
 
@@ -41,54 +38,10 @@ def find_extra_reqs(
         ignore_modules_function=ignore_modules_function,
     ).found
 
-    installed_files: dict[Path, str] = {}
-    packages_info = common.get_packages_info()
-    installed_names: set[NormalizedName] = set()
-
-    for package in packages_info:
-        package_name = package.name
-        package_location = package.location
-        installed_names.add(canonicalize_name(package_name))
-
-        log.debug(
-            "installed package: %s (at %s)",
-            package_name,
-            package_location,
-        )
-        for item in package.files or []:
-            path = Path(package_location) / item
-            path = common.cached_resolve_path(path=path)
-
-            installed_files[path] = package_name
-            package_path = common.package_path(path=path)
-            if package_path:
-                # we've seen a package file so add the bare package directory
-                # to the installed list as well as we might want to look up
-                # a package by its directory path later
-                installed_files[package_path] = package_name
+    installed_names = common.installed_distribution_names()
 
     # 3. match imported modules against those packages
-    used: collections.defaultdict[
-        NormalizedName,
-        list[common.FoundModule],
-    ] = collections.defaultdict(list)
-
-    for modname, info in used_modules.items():
-        # probably standard library if it's not in the files list
-        if info.filename in installed_files:
-            used_name = canonicalize_name(installed_files[info.filename])
-            log.debug(
-                "used module: %s (from package %s)",
-                modname,
-                installed_files[info.filename],
-            )
-            used[used_name].append(info)
-        else:
-            log.debug(
-                "used module: %s (from file %s, assuming stdlib or local)",
-                modname,
-                info.filename,
-            )
+    used = common.used_packages(used_modules=used_modules, paths=paths)
 
     # 4. compare with requirements
     explicit = common.find_required_modules(

--- a/pip_check_reqs/find_missing_reqs.py
+++ b/pip_check_reqs/find_missing_reqs.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import argparse
-import collections
 import logging
 import sys
 from pathlib import Path
@@ -35,51 +34,8 @@ def find_missing_reqs(
     )
     used_modules = imported_modules.found
 
-    installed_files: dict[Path, str] = {}
-    packages_info = common.get_packages_info()
-
-    for package in packages_info:
-        package_name = package.name
-        package_location = package.location
-
-        log.debug(
-            "installed package: %s (at %s)",
-            package_name,
-            package_location,
-        )
-        for item in package.files or []:
-            path = Path(package_location) / item
-            path = common.cached_resolve_path(path=path)
-
-            installed_files[path] = package_name
-            package_path = common.package_path(path=path)
-            if package_path:
-                # we've seen a package file so add the bare package directory
-                # to the installed list as well as we might want to look up
-                # a package by its directory path later
-                installed_files[package_path] = package_name
-
     # 3. match imported modules against those packages
-    used: collections.defaultdict[
-        NormalizedName,
-        list[common.FoundModule],
-    ] = collections.defaultdict(list)
-    for modname, info in used_modules.items():
-        # probably standard library if it's not in the files list
-        if info.filename in installed_files:
-            used_name = canonicalize_name(name=installed_files[info.filename])
-            log.debug(
-                "used module: %s (from package %s)",
-                modname,
-                installed_files[info.filename],
-            )
-            used[used_name].append(info)
-        else:
-            log.debug(
-                "used module: %s (from file %s, assuming stdlib or local)",
-                modname,
-                info.filename,
-            )
+    used = common.used_packages(used_modules=used_modules, paths=paths)
 
     # 4. compare with requirements
     explicit: set[NormalizedName] = set()

--- a/spelling_private_dict.txt
+++ b/spelling_private_dict.txt
@@ -1,3 +1,4 @@
+backend
 cli
 pragma
 pyright

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,114 @@
+"""Fixtures shared between test modules."""
+
+from __future__ import annotations
+
+import json
+import textwrap
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import pytest
+
+from pip_check_reqs import common
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+
+@dataclass(frozen=True)
+class EditableInstall:
+    """A distribution installed in editable mode."""
+
+    distribution_name: str
+    module_name: str
+    source_directory: Path
+    """The directory of the project, which the modules are imported from."""
+
+
+def write_dist_info(
+    *,
+    site_packages: Path,
+    distribution_name: str,
+    direct_url: dict[str, object] | None,
+) -> None:
+    """Write the ``.dist-info`` directory of an installed distribution."""
+    # A ``.dist-info`` directory is named after the normalized distribution
+    # name, in which a hyphen is written as an underscore.
+    normalized_name = distribution_name.replace("-", "_")
+    dist_info = site_packages / f"{normalized_name}-1.0.dist-info"
+    dist_info.mkdir(parents=True)
+    (dist_info / "INSTALLER").write_text("pip\n", encoding="utf-8")
+    (dist_info / "METADATA").write_text(
+        textwrap.dedent(
+            f"""\
+            Metadata-Version: 2.1
+            Name: {distribution_name}
+            Version: 1.0
+            """,
+        ),
+        encoding="utf-8",
+    )
+    # An editable install records the import hook which pip installed, and
+    # not the modules of the distribution.
+    (dist_info / "RECORD").write_text(
+        f"{dist_info.name}/METADATA,,\n",
+        encoding="utf-8",
+    )
+    if direct_url is not None:
+        (dist_info / "direct_url.json").write_text(
+            json.dumps(direct_url),
+            encoding="utf-8",
+        )
+
+
+@pytest.fixture
+def editable_install(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Iterator[EditableInstall]:
+    """Install a distribution in editable mode, as ``pip install -e`` does.
+
+    An editable install imports its modules from the project directory, which
+    is on ``sys.path``, rather than from a copy in ``site-packages``. The
+    ``.dist-info`` directory of the install records the project directory in
+    ``direct_url.json``, as described by PEP 610.
+    """
+    distribution_name = "editable-package-12345"
+    module_name = "editable_package_12345"
+
+    source_directory = tmp_path / "editable-project"
+    package_directory = source_directory / module_name
+    package_directory.mkdir(parents=True)
+    (package_directory / "__init__.py").touch()
+
+    site_packages = tmp_path / "editable-site-packages"
+    write_dist_info(
+        site_packages=site_packages,
+        distribution_name=distribution_name,
+        direct_url={
+            "url": source_directory.as_uri(),
+            "dir_info": {"editable": True},
+        },
+    )
+
+    monkeypatch.syspath_prepend(  # pyright: ignore[reportUnknownMemberType]
+        str(source_directory),
+    )
+    monkeypatch.syspath_prepend(  # pyright: ignore[reportUnknownMemberType]
+        str(site_packages),
+    )
+
+    common.get_packages_info.cache_clear()
+    common.editable_source_directories.cache_clear()
+
+    yield EditableInstall(
+        distribution_name=distribution_name,
+        module_name=module_name,
+        source_directory=source_directory,
+    )
+
+    # The distribution goes away with the temporary directory, so the caches
+    # must not describe it for the tests which follow.
+    common.get_packages_info.cache_clear()
+    common.editable_source_directories.cache_clear()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import textwrap
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
@@ -14,6 +15,14 @@ from pip_check_reqs import common
 if TYPE_CHECKING:
     from collections.abc import Iterator
     from pathlib import Path
+
+# On Python 3.10, pip reads the environment through ``pkg_resources``, whose
+# working set is a snapshot taken when it was first imported. A distribution
+# which a test installs is added to ``sys.path`` after that, so pip does not
+# see it. Ask pip for the ``importlib.metadata`` backend, which reads
+# ``sys.path`` as it is when it is asked. Python 3.14 uses that backend
+# already, and pip removes the other one in version 26.3.
+os.environ["_PIP_USE_IMPORTLIB_METADATA"] = "1"
 
 
 @dataclass(frozen=True)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -16,6 +16,8 @@ import pytest
 import __main__
 from pip_check_reqs import __version__, common
 
+from .conftest import write_dist_info
+
 
 @pytest.mark.parametrize(
     ("path", "result"),
@@ -151,6 +153,26 @@ def test_find_imported_modules_frozen(
     spam = tmp_path / "spam.py"
     statement = f"import {frozen_item_names[0]}"
     spam.write_text(data=statement)
+
+    result = common.find_imported_modules(
+        paths=[tmp_path],
+        ignore_files_function=common.ignorer(ignore_cfg=[]),
+        ignore_modules_function=common.ignorer(ignore_cfg=[]),
+    ).found
+
+    assert set(result.keys()) == set()
+
+
+def test_find_imported_modules_built_in(
+    tmp_path: Path,
+) -> None:
+    """Built-in modules are not included in the result.
+
+    A built-in module is compiled into the interpreter, so it has no file
+    which could belong to a distribution.
+    """
+    spam = tmp_path / "spam.py"
+    spam.write_text(data="import sys")
 
     result = common.find_imported_modules(
         paths=[tmp_path],
@@ -299,7 +321,7 @@ def test_find_imported_modules_missing_from_submodule(
         (
             False,
             False,
-            ["ast", "pathlib", "hashlib", "sys"],
+            ["ast", "pathlib", "hashlib"],
             [
                 ("spam.py", 2),
                 ("ham.py", 2),
@@ -308,11 +330,11 @@ def test_find_imported_modules_missing_from_submodule(
         (
             False,
             True,
-            ["ast", "pathlib", "sys"],
+            ["ast", "pathlib"],
             [("spam.py", 2), ("ham.py", 2)],
         ),
-        (True, False, ["ast", "sys"], [("spam.py", 2)]),
-        (True, True, ["ast", "sys"], [("spam.py", 2)]),
+        (True, False, ["ast"], [("spam.py", 2)]),
+        (True, True, ["ast"], [("spam.py", 2)]),
     ],
 )
 def test_find_imported_modules_advanced(
@@ -871,3 +893,65 @@ def test_wrong_environment_warning_in_color(tmp_path: Path) -> None:
     yellow = "\033[33m"
     reset = "\033[0m"
     assert warning == f"{yellow}{plain_warning}{reset}"
+
+
+def test_editable_source_directories(
+    *,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Only a distribution installed in editable mode has a source directory.
+
+    A distribution installed from a local directory records that directory in
+    ``direct_url.json`` just as an editable install does, but its modules are
+    copied into ``site-packages``, so the directory does not provide them.
+    """
+    site_packages = tmp_path / "site-packages"
+    editable_source_directory = tmp_path / "editable-project"
+    write_dist_info(
+        site_packages=site_packages,
+        distribution_name="editable-package-12345",
+        direct_url={
+            "url": editable_source_directory.as_uri(),
+            "dir_info": {"editable": True},
+        },
+    )
+    write_dist_info(
+        site_packages=site_packages,
+        distribution_name="copied-package-12345",
+        direct_url={
+            "url": (tmp_path / "copied-project").as_uri(),
+            "dir_info": {},
+        },
+    )
+    write_dist_info(
+        site_packages=site_packages,
+        distribution_name="index-package-12345",
+        direct_url=None,
+    )
+
+    monkeypatch.syspath_prepend(  # pyright: ignore[reportUnknownMemberType]
+        str(site_packages),
+    )
+    common.editable_source_directories.cache_clear()
+
+    try:
+        directories = common.editable_source_directories()
+    finally:
+        common.editable_source_directories.cache_clear()
+
+    # The environment the tests run in may have editable installs of its
+    # own, so we look only at the distributions we wrote.
+    written_names = {
+        "editable-package-12345",
+        "copied-package-12345",
+        "index-package-12345",
+    }
+    written_directories = {
+        directory: name
+        for directory, name in directories.items()
+        if name in written_names
+    }
+    assert written_directories == {
+        editable_source_directory.resolve(): "editable-package-12345",
+    }

--- a/tests/test_find_extra_reqs.py
+++ b/tests/test_find_extra_reqs.py
@@ -7,11 +7,15 @@ import re
 import sys
 import textwrap
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pip  # This happens to be installed in the test environment.
 import pytest
 
 from pip_check_reqs import common, find_extra_reqs
+
+if TYPE_CHECKING:
+    from .conftest import EditableInstall
 
 
 def test_find_extra_reqs(tmp_path: Path) -> None:
@@ -343,3 +347,64 @@ def test_main_does_not_warn_when_run_from_the_active_environment(
     )
 
     assert capsys.readouterr().err == ""
+
+
+def test_editable_requirement_is_not_extra(
+    *,
+    editable_install: EditableInstall,
+    tmp_path: Path,
+) -> None:
+    """A requirement installed in editable mode and imported is not extra.
+
+    The files of an editable install are an import hook rather than the
+    modules of the distribution, so the modules it provides are only found by
+    looking at the project directory which it is installed from.
+    """
+    fake_requirements_file = tmp_path / "requirements.txt"
+    fake_requirements_file.write_text(
+        editable_install.distribution_name + "\n",
+    )
+
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    source_file = source_dir / "source.py"
+    source_file.write_text(f"import {editable_install.module_name}\n")
+
+    result = find_extra_reqs.find_extra_reqs(
+        requirements_filename=fake_requirements_file,
+        paths=[source_dir],
+        ignore_files_function=common.ignorer(ignore_cfg=[]),
+        ignore_modules_function=common.ignorer(ignore_cfg=[]),
+        ignore_requirements_function=common.ignorer(ignore_cfg=[]),
+        skip_incompatible=False,
+    )
+
+    assert not result
+
+
+def test_editable_requirement_not_imported_is_extra(
+    *,
+    editable_install: EditableInstall,
+    tmp_path: Path,
+) -> None:
+    """A requirement installed in editable mode is extra when not imported."""
+    fake_requirements_file = tmp_path / "requirements.txt"
+    fake_requirements_file.write_text(
+        editable_install.distribution_name + "\n",
+    )
+
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    source_file = source_dir / "source.py"
+    source_file.write_text("import pprint\n")
+
+    result = find_extra_reqs.find_extra_reqs(
+        requirements_filename=fake_requirements_file,
+        paths=[source_dir],
+        ignore_files_function=common.ignorer(ignore_cfg=[]),
+        ignore_modules_function=common.ignorer(ignore_cfg=[]),
+        ignore_requirements_function=common.ignorer(ignore_cfg=[]),
+        skip_incompatible=False,
+    )
+
+    assert result == [editable_install.distribution_name]

--- a/tests/test_find_missing_reqs.py
+++ b/tests/test_find_missing_reqs.py
@@ -7,11 +7,15 @@ import re
 import sys
 import textwrap
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pip  # This happens to be installed in the test environment.
 import pytest
 
 from pip_check_reqs import common, find_missing_reqs
+
+if TYPE_CHECKING:
+    from .conftest import EditableInstall
 
 
 def test_find_missing_reqs(tmp_path: Path) -> None:
@@ -518,3 +522,66 @@ def test_main_does_not_warn_when_run_from_the_active_environment(
     )
 
     assert capsys.readouterr().err == ""
+
+
+def test_editable_requirement_is_missing(
+    *,
+    editable_install: EditableInstall,
+    tmp_path: Path,
+) -> None:
+    """An import of an editable install which is not required is reported.
+
+    The files of an editable install are an import hook rather than the
+    modules of the distribution, so the modules it provides are only found by
+    looking at the project directory which it is installed from.
+    """
+    fake_requirements_file = tmp_path / "requirements.txt"
+    fake_requirements_file.write_text("")
+
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    source_file = source_dir / "source.py"
+    source_file.write_text(f"import {editable_install.module_name}\n")
+
+    result = find_missing_reqs.find_missing_reqs(
+        requirements_filename=fake_requirements_file,
+        paths=[source_dir],
+        ignore_files_function=common.ignorer(ignore_cfg=[]),
+        ignore_modules_function=common.ignorer(ignore_cfg=[]),
+    )
+
+    (name, uses) = next(iter(result))
+    assert name == editable_install.distribution_name
+    assert [use.modname for use in uses] == [editable_install.module_name]
+
+
+def test_own_source_installed_as_editable_is_not_missing(
+    *,
+    editable_install: EditableInstall,
+    tmp_path: Path,
+) -> None:
+    """The source we scan is not a requirement of itself.
+
+    A project is commonly installed in editable mode while it is worked on,
+    and its own modules are then provided by an editable install. They are
+    the source we check rather than a distribution it requires, so they are
+    not reported.
+    """
+    fake_requirements_file = tmp_path / "requirements.txt"
+    fake_requirements_file.write_text("")
+
+    source_file = (
+        editable_install.source_directory
+        / editable_install.module_name
+        / "uses_own_package.py"
+    )
+    source_file.write_text(f"import {editable_install.module_name}\n")
+
+    result = find_missing_reqs.find_missing_reqs(
+        requirements_filename=fake_requirements_file,
+        paths=[editable_install.source_directory],
+        ignore_files_function=common.ignorer(ignore_cfg=[]),
+        ignore_modules_function=common.ignorer(ignore_cfg=[]),
+    )
+
+    assert not result


### PR DESCRIPTION
Fixes #45. The files recorded for an editable install are the import hook pip installed rather than the distribution's modules, so `pip-extra-reqs` reported an editable requirement as extra even when the code imported it, and `pip-missing-reqs` never reported an import of an editable dependency which was not required. Both commands now take the project directory from `direct_url.json` (PEP 610) and attribute modules imported from it to that distribution, while a module of the source being scanned stays local so a project installed editable is not treated as a requirement of itself.

The module-to-distribution matching was duplicated between the two commands, so it now lives in `common.used_packages()`. A built-in module such as `sys` has an origin of `"built-in"` rather than a path, which we turned into a path relative to the working directory and which then matched an editable directory, so it is now skipped as a frozen module is; this changes `find_imported_modules` results but not reported output, as built-ins never mapped to a distribution.

Verified against a real editable install in a virtual environment before and after the change, and covered by new tests using a fixture which simulates an editable install; the suite passes at 100% coverage with all lint checks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core import-to-distribution resolution used by both CLI tools; incorrect PEP 610 path handling or scan-path exclusion could mis-report requirements, though behaviour is well covered by new tests.
> 
> **Overview**
> **`pip-extra-reqs` and `pip-missing-reqs` now attribute imports to distributions installed with `pip install -e`.** Editable installs only record the import hook in installed file lists, not the real module paths, so used-to-required matching was wrong: extras were flagged when code imported the package, and missing reqs were not reported when an editable dependency was imported but not listed.
> 
> The shared logic lives in **`common.used_packages()`**, which maps module files via normal `site-packages` installs and, for editables, via **`direct_url.json`** (PEP 610) source directories. Modules under the paths being scanned are **not** counted as external requirements, so a project checked in its own editable tree does not require itself.
> 
> **Import scanning** treats **`built-in`** origins like **`frozen`** (skip file attribution), fixing false matches against editable directories when builtins such as `sys` were resolved to paths. **`find_imported_modules`** no longer requires `origin` to be a regular file before recording a module path.
> 
> Docs (**CHANGELOG**, **README**) describe editable behaviour; tests add **`editable_install`** fixtures and coverage for extra/missing/self-scan cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ff0ff25ffd8895a615cb34cfff6b36d6e1f92ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->