### PR TITLE
Name a URL or directory requirement from its install

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,10 +14,14 @@ Release History
   ``SyntaxError`` traceback.
 - An import from a submodule that does not exist is no longer attributed to
   an installed parent distribution, which removed a class of false positives.
-- A requirement with no distribution name, such as a bare
-  ``git+ssh://...`` URL, now reports an error asking for an ``#egg=<name>``
-  fragment in both commands. It previously crashed with an
-  ``AssertionError``.
+- A requirement with no distribution name, such as ``-e .`` or a bare
+  ``git+ssh://...`` URL, is now matched to the installed distribution which
+  was installed from that directory or URL. When no such distribution is
+  installed, both commands report an error asking for an ``#egg=<name>``
+  fragment. They previously crashed with an ``AssertionError``.
+- A requirement which pip cannot read, such as a directory with no
+  ``pyproject.toml``, now reports a command line error. It previously showed
+  a pip traceback.
 - On Windows, an ignore glob no longer crashes with a ``ValueError`` when a
   source file is on a different drive to the working directory.
 - Both commands now warn when they are run from outside the active virtual

--- a/README.rst
+++ b/README.rst
@@ -82,6 +82,12 @@ you give to the commands is the project being checked rather than a
 requirement of it, so a module of that source is not treated as a
 requirement even when the project itself is installed in editable mode.
 
+A requirement given as a URL or a directory, such as ``-e .`` or
+``git+https://github.com/org/repo.git``, does not name a distribution. When
+the requirement is installed, both commands take the name from the install,
+which records where it came from. Otherwise, name the distribution with an
+``#egg=<name>`` fragment.
+
 Sample tox.ini configuration
 ----------------------------
 

--- a/pip_check_reqs/common.py
+++ b/pip_check_reqs/common.py
@@ -22,17 +22,22 @@ from pip._internal.commands.show import (
     _PackageInfo,  # pyright: ignore[reportPrivateUsage]
     search_packages_info,
 )
+from pip._internal.exceptions import InstallationError
 from pip._internal.network.session import PipSession
 from pip._internal.req.constructors import install_req_from_line
-from pip._internal.req.req_file import ParsedRequirement, parse_requirements
+from pip._internal.req.req_file import parse_requirements
 from pip._internal.utils.urls import url_to_path
+from pip._internal.vcs.versioncontrol import vcs
 
 from . import __version__
 
 if TYPE_CHECKING:
     import argparse
-    from collections.abc import Callable, Generator, Iterable
-    from typing import NoReturn, TextIO
+    from collections.abc import Callable, Generator, Iterable, Iterator
+    from typing import Any, NoReturn, TextIO
+
+    from pip._internal.models.link import Link
+    from pip._internal.req.req_file import ParsedRequirement
 
 log = logging.getLogger(__name__)
 
@@ -414,6 +419,23 @@ def _installed_files() -> dict[Path, str]:
     return installed_files
 
 
+def _direct_urls() -> Iterator[tuple[str, dict[str, Any]]]:
+    """Yield the name and direct URL of each distribution installed from one.
+
+    A distribution installed from a URL, a local directory or a version
+    control repository, rather than from an index, records where it came from
+    in ``direct_url.json``, as described by PEP 610.
+    """
+    for distribution in importlib.metadata.distributions():
+        direct_url_text = distribution.read_text("direct_url.json")
+        if direct_url_text is None:
+            continue
+
+        name: str = distribution.metadata["Name"]
+        direct_url: dict[str, Any] = json.loads(direct_url_text)
+        yield name, direct_url
+
+
 @cache
 def editable_source_directories() -> dict[Path, str]:
     """Map the source directory of each editable install to its distribution.
@@ -426,12 +448,7 @@ def editable_source_directories() -> dict[Path, str]:
     described by PEP 610, so we take it from there.
     """
     directories: dict[Path, str] = {}
-    for distribution in importlib.metadata.distributions():
-        direct_url_text = distribution.read_text("direct_url.json")
-        if direct_url_text is None:
-            continue
-
-        direct_url = json.loads(direct_url_text)
+    for name, direct_url in _direct_urls():
         directory_info = direct_url.get("dir_info", {})
         if not directory_info.get("editable", False):
             continue
@@ -441,9 +458,111 @@ def editable_source_directories() -> dict[Path, str]:
         directory = cached_resolve_path(
             path=Path(url_to_path(direct_url["url"])),
         )
-        directories[directory] = distribution.metadata["Name"]
+        directories[directory] = name
 
     return directories
+
+
+def _direct_url_key(
+    *,
+    url: str,
+    vcs_name: str | None,
+    subdirectory: str | None,
+) -> str:
+    """Return a key which identifies the project a direct URL points at.
+
+    A local directory may be written as a relative path in one place and as
+    an absolute ``file`` URL in another, so it is keyed by its resolved path.
+    A version control URL is keyed with the name of the version control
+    system, as ``git+https://...`` is written in a requirements file.
+    A repository may hold several projects, each in its own subdirectory, so
+    the subdirectory is part of the key.
+    """
+    if vcs_name is not None:
+        key = f"{vcs_name}+{url}"
+    elif url.startswith("file:"):
+        key = str(cached_resolve_path(path=Path(url_to_path(url))))
+    else:
+        key = url
+
+    if subdirectory is not None:
+        key = f"{key}#subdirectory={subdirectory}"
+    return key
+
+
+@cache
+def direct_url_distribution_names() -> dict[str, str]:
+    """Map the direct URL each distribution was installed from to its name.
+
+    The keys are as ``_direct_url_key`` gives them.
+    """
+    names: dict[str, str] = {}
+    for name, direct_url in _direct_urls():
+        vcs_info = direct_url.get("vcs_info")
+        vcs_name = vcs_info["vcs"] if vcs_info is not None else None
+        key = _direct_url_key(
+            url=direct_url["url"],
+            vcs_name=vcs_name,
+            subdirectory=direct_url.get("subdirectory"),
+        )
+        names[key] = name
+    return names
+
+
+def _link_key(*, link: Link) -> str:
+    """Return the ``_direct_url_key`` of the project a requirement points at.
+
+    A requirement may pin a revision, as ``git+https://...@v1.0`` does, and
+    may carry an ``#egg=`` fragment. Neither is recorded in the install, so
+    both are left out of the key.
+    """
+    if link.is_vcs:
+        backend = vcs.get_backend_for_scheme(link.scheme)
+        assert backend is not None
+        url, _revision, _auth = backend.get_url_rev_and_auth(
+            link.url_without_fragment,
+        )
+        return _direct_url_key(
+            url=url,
+            vcs_name=backend.name,
+            subdirectory=link.subdirectory_fragment,
+        )
+    return _direct_url_key(
+        url=link.url_without_fragment,
+        vcs_name=None,
+        subdirectory=link.subdirectory_fragment,
+    )
+
+
+def _requirement_name(*, requirement: ParsedRequirement) -> str | None:
+    """Return the name of the distribution a requirement line asks for.
+
+    Return ``None`` when the name cannot be told from the line and the
+    requirement is not installed.
+
+    A direct URL such as ``git+ssh://git@example.com/org/repo.git`` or a
+    local directory such as ``-e .`` carries no distribution name, and pip
+    will not learn one without fetching or building the project. When such a
+    requirement is installed, the install records the URL it came from, so
+    we take the name from the install.
+    """
+    try:
+        install_requirement = install_req_from_line(requirement.requirement)
+    except InstallationError as exc:
+        # pip describes the problem over several lines, with a caret under
+        # the part of the line it could not read. We report the requirement
+        # as an input error, so we keep only the first line of the reason.
+        reason = str(exc).splitlines()[0]
+        msg = f"could not parse requirement: {reason}"
+        raise ValueError(msg) from exc
+
+    if install_requirement.name is not None:
+        return install_requirement.name
+
+    # A requirement with no name is a URL or a path, so it has a link.
+    link = install_requirement.link
+    assert link is not None
+    return direct_url_distribution_names().get(_link_key(link=link))
 
 
 def _editable_distribution_name(
@@ -508,10 +627,7 @@ def used_packages(
 
 def find_required_modules(
     *,
-    ignore_requirements_function: Callable[
-        [str | ParsedRequirement],
-        bool,
-    ],
+    ignore_requirements_function: Callable[[str], bool],
     skip_incompatible: bool,
     requirements_filename: Path,
 ) -> set[NormalizedName]:
@@ -520,20 +636,19 @@ def find_required_modules(
         str(requirements_filename),
         session=PipSession(),
     ):
-        requirement_name = install_req_from_line(
-            requirement.requirement,
-        ).name
+        requirement_name = _requirement_name(requirement=requirement)
         if requirement_name is None:
-            # A direct URL such as ``git+ssh://git@example.com/org/repo.git``
-            # carries no distribution name, and pip will not learn one without
-            # fetching the project. Skipping the line would silently drop a
-            # requirement and report the modules it provides as missing, so
-            # ask for the name instead of guessing at it.
-            hint = "Add an '#egg=<name>' fragment naming the distribution."
+            # Skipping the line would silently drop a requirement and report
+            # the modules it provides as missing, so ask for the name instead
+            # of guessing at it.
+            hint = (
+                "Install it, or add an '#egg=<name>' fragment naming the "
+                "distribution."
+            )
             msg = f"requirement has no name: {requirement.requirement}. {hint}"
             raise ValueError(msg)
 
-        if ignore_requirements_function(requirement):
+        if ignore_requirements_function(requirement_name):
             log.debug("ignoring requirement: %s", requirement_name)
             continue
 
@@ -580,29 +695,20 @@ def package_path(*, path: Path) -> Path | None:
     return path.parent
 
 
-def _null_ignorer(_: str | ParsedRequirement) -> bool:
+def _null_ignorer(_: str) -> bool:
     return False
 
 
-def ignorer(*, ignore_cfg: list[str]) -> Callable[..., bool]:
+def ignorer(*, ignore_cfg: list[str]) -> Callable[[str], bool]:
     if not ignore_cfg:
         return _null_ignorer
 
     def ignorer_function(
-        candidate: str | ParsedRequirement,
+        candidate_path: str,
         ignore_cfg: list[str] = ignore_cfg,
     ) -> bool:
         working_directory = Path.cwd()
         for ignore in ignore_cfg:
-            if isinstance(candidate, str):
-                candidate_path = candidate
-            else:
-                optional_candidate_path = install_req_from_line(
-                    candidate.requirement,
-                ).name
-                assert isinstance(optional_candidate_path, str)
-                candidate_path = optional_candidate_path
-
             if fnmatch.fnmatch(candidate_path, ignore):
                 return True
 

--- a/pip_check_reqs/find_extra_reqs.py
+++ b/pip_check_reqs/find_extra_reqs.py
@@ -13,8 +13,6 @@ from pip_check_reqs import common
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable
 
-    from pip._internal.req.req_file import ParsedRequirement
-
 log = logging.getLogger(__name__)
 
 
@@ -24,10 +22,7 @@ def find_extra_reqs(
     paths: Iterable[Path],
     ignore_files_function: Callable[[str], bool],
     ignore_modules_function: Callable[[str], bool],
-    ignore_requirements_function: Callable[
-        [str | ParsedRequirement],
-        bool,
-    ],
+    ignore_requirements_function: Callable[[str], bool],
     skip_incompatible: bool,
 ) -> list[str]:
     # 1. find files used by imports in the code (as best we can without

--- a/spelling_private_dict.txt
+++ b/spelling_private_dict.txt
@@ -6,4 +6,5 @@ pytest
 reportPrivateUsage
 reportUnknownMemberType
 reqs
+subdirectory
 traceback

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -90,6 +90,19 @@ def editable_install(
     package_directory = source_directory / module_name
     package_directory.mkdir(parents=True)
     (package_directory / "__init__.py").touch()
+    # pip only accepts a directory as a requirement when it is a project, so
+    # the directory must have a ``pyproject.toml`` to be written in a
+    # requirements file.
+    (source_directory / "pyproject.toml").write_text(
+        textwrap.dedent(
+            f"""\
+            [project]
+            name = "{distribution_name}"
+            version = "1.0"
+            """,
+        ),
+        encoding="utf-8",
+    )
 
     site_packages = tmp_path / "editable-site-packages"
     write_dist_info(
@@ -110,6 +123,7 @@ def editable_install(
 
     common.get_packages_info.cache_clear()
     common.editable_source_directories.cache_clear()
+    common.direct_url_distribution_names.cache_clear()
 
     yield EditableInstall(
         distribution_name=distribution_name,
@@ -121,3 +135,4 @@ def editable_install(
     # must not describe it for the tests which follow.
     common.get_packages_info.cache_clear()
     common.editable_source_directories.cache_clear()
+    common.direct_url_distribution_names.cache_clear()

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -10,6 +10,7 @@ import textwrap
 import types
 import uuid
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -17,6 +18,9 @@ import __main__
 from pip_check_reqs import __version__, common
 
 from .conftest import write_dist_info
+
+if TYPE_CHECKING:
+    from .conftest import EditableInstall
 
 
 @pytest.mark.parametrize(
@@ -799,7 +803,9 @@ def test_find_required_modules_unnamed_requirement(tmp_path: Path) -> None:
             requirements_filename=fake_requirements_file,
         )
 
-    hint = "Add an '#egg=<name>' fragment naming the distribution."
+    hint = (
+        "Install it, or add an '#egg=<name>' fragment naming the distribution."
+    )
     expected_message = f"requirement has no name: {url}. {hint}"
     assert str(excinfo.value) == expected_message
 
@@ -817,6 +823,159 @@ def test_find_required_modules_egg_fragment_names_requirement(
         requirements_filename=fake_requirements_file,
     )
     assert reqs == {"foobar", "repo"}
+
+
+@pytest.mark.parametrize(
+    "line_template",
+    [
+        pytest.param("-e {directory}", id="editable"),
+        pytest.param("{directory}", id="not editable"),
+        pytest.param("file://{directory}", id="file URL"),
+    ],
+)
+def test_find_required_modules_installed_directory_requirement(
+    *,
+    editable_install: EditableInstall,
+    tmp_path: Path,
+    line_template: str,
+) -> None:
+    """A local directory requirement is named by the install made from it.
+
+    ``-e .`` is a common line in a requirements file, and it carries no
+    distribution name. The install records the directory it was made from,
+    so the name is taken from the install.
+    """
+    fake_requirements_file = tmp_path / "requirements.txt"
+    line = line_template.format(directory=editable_install.source_directory)
+    fake_requirements_file.write_text(f"foobar==1\n{line}\n")
+
+    reqs = common.find_required_modules(
+        ignore_requirements_function=common.ignorer(ignore_cfg=[]),
+        skip_incompatible=False,
+        requirements_filename=fake_requirements_file,
+    )
+
+    assert reqs == {"foobar", editable_install.distribution_name}
+
+
+def test_find_required_modules_relative_directory_requirement(
+    *,
+    editable_install: EditableInstall,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A directory requirement is matched to an install by its resolved path.
+
+    A requirements file usually names the project directory relative to the
+    working directory, as ``-e .`` does, while the install records an
+    absolute ``file`` URL.
+    """
+    monkeypatch.chdir(editable_install.source_directory)
+    fake_requirements_file = tmp_path / "requirements.txt"
+    fake_requirements_file.write_text("-e .\n")
+
+    reqs = common.find_required_modules(
+        ignore_requirements_function=common.ignorer(ignore_cfg=[]),
+        skip_incompatible=False,
+        requirements_filename=fake_requirements_file,
+    )
+
+    assert reqs == {editable_install.distribution_name}
+
+
+@pytest.mark.parametrize(
+    ("line", "direct_url"),
+    [
+        pytest.param(
+            "git+https://example.com/org/repo.git@v1.0#subdirectory=sub",
+            {
+                "url": "https://example.com/org/repo.git",
+                "vcs_info": {"vcs": "git", "commit_id": "abc123"},
+                "subdirectory": "sub",
+            },
+            id="git with revision and subdirectory",
+        ),
+        pytest.param(
+            "git+ssh://git@example.com/org/repo.git",
+            {
+                "url": "ssh://git@example.com/org/repo.git",
+                "vcs_info": {"vcs": "git", "commit_id": "abc123"},
+            },
+            id="git over ssh",
+        ),
+        pytest.param(
+            "https://example.com/downloads/repo-1.0.tar.gz",
+            {
+                "url": "https://example.com/downloads/repo-1.0.tar.gz",
+                "archive_info": {},
+            },
+            id="archive",
+        ),
+    ],
+)
+def test_find_required_modules_installed_url_requirement(
+    *,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    line: str,
+    direct_url: dict[str, object],
+) -> None:
+    """A URL requirement is named by the install made from that URL.
+
+    A requirement may pin a revision, which the install does not record as
+    part of the URL, so the revision is left out when matching. A repository
+    may hold several projects, so the subdirectory is matched too.
+    """
+    distribution_name = "url-package-12345"
+    site_packages = tmp_path / "site-packages"
+    write_dist_info(
+        site_packages=site_packages,
+        distribution_name=distribution_name,
+        direct_url=direct_url,
+    )
+    monkeypatch.syspath_prepend(  # pyright: ignore[reportUnknownMemberType]
+        str(site_packages),
+    )
+    common.direct_url_distribution_names.cache_clear()
+
+    fake_requirements_file = tmp_path / "requirements.txt"
+    fake_requirements_file.write_text(f"foobar==1\n{line}\n")
+
+    try:
+        reqs = common.find_required_modules(
+            ignore_requirements_function=common.ignorer(ignore_cfg=[]),
+            skip_incompatible=False,
+            requirements_filename=fake_requirements_file,
+        )
+    finally:
+        common.direct_url_distribution_names.cache_clear()
+
+    assert reqs == {"foobar", distribution_name}
+
+
+def test_find_required_modules_unparseable_requirement(tmp_path: Path) -> None:
+    """A requirement which pip cannot read is reported as an input error.
+
+    A directory with no ``pyproject.toml`` or ``setup.py`` is not a project,
+    so pip refuses it. That previously surfaced as a pip traceback.
+    """
+    empty_directory = tmp_path / "empty"
+    empty_directory.mkdir()
+    fake_requirements_file = tmp_path / "requirements.txt"
+    fake_requirements_file.write_text(f"{empty_directory}\n")
+
+    with pytest.raises(ValueError, match="could not parse") as excinfo:
+        common.find_required_modules(
+            ignore_requirements_function=common.ignorer(ignore_cfg=[]),
+            skip_incompatible=False,
+            requirements_filename=fake_requirements_file,
+        )
+
+    expected_message = (
+        f"could not parse requirement: Directory '{empty_directory}' is not "
+        "installable. Neither 'setup.py' nor 'pyproject.toml' found."
+    )
+    assert str(excinfo.value) == expected_message
 
 
 def test_version_info_shows_version_number() -> None:

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -20,6 +20,8 @@ from pip_check_reqs import __version__, common
 from .conftest import write_dist_info
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from .conftest import EditableInstall
 
 
@@ -825,19 +827,33 @@ def test_find_required_modules_egg_fragment_names_requirement(
     assert reqs == {"foobar", "repo"}
 
 
+def _editable_line(directory: Path) -> str:
+    """Return an ``-e`` requirement line for a directory.
+
+    pip splits an editable line as a shell does, so a backslash in a Windows
+    path is lost. Windows accepts a forward slash instead.
+    """
+    return f"-e {directory.as_posix()}"
+
+
+def _file_url_line(directory: Path) -> str:
+    """Return a ``file`` URL requirement line for a directory."""
+    return directory.as_uri()
+
+
 @pytest.mark.parametrize(
-    "line_template",
+    "line_for_directory",
     [
-        pytest.param("-e {directory}", id="editable"),
-        pytest.param("{directory}", id="not editable"),
-        pytest.param("file://{directory}", id="file URL"),
+        pytest.param(_editable_line, id="editable"),
+        pytest.param(str, id="not editable"),
+        pytest.param(_file_url_line, id="file URL"),
     ],
 )
 def test_find_required_modules_installed_directory_requirement(
     *,
     editable_install: EditableInstall,
     tmp_path: Path,
-    line_template: str,
+    line_for_directory: Callable[[Path], str],
 ) -> None:
     """A local directory requirement is named by the install made from it.
 
@@ -846,7 +862,7 @@ def test_find_required_modules_installed_directory_requirement(
     so the name is taken from the install.
     """
     fake_requirements_file = tmp_path / "requirements.txt"
-    line = line_template.format(directory=editable_install.source_directory)
+    line = line_for_directory(editable_install.source_directory)
     fake_requirements_file.write_text(f"foobar==1\n{line}\n")
 
     reqs = common.find_required_modules(
@@ -971,9 +987,11 @@ def test_find_required_modules_unparseable_requirement(tmp_path: Path) -> None:
             requirements_filename=fake_requirements_file,
         )
 
+    # pip quotes the directory as Python does, so a backslash in a Windows
+    # path is doubled.
     expected_message = (
-        f"could not parse requirement: Directory '{empty_directory}' is not "
-        "installable. Neither 'setup.py' nor 'pyproject.toml' found."
+        f"could not parse requirement: Directory {str(empty_directory)!r} is "
+        "not installable. Neither 'setup.py' nor 'pyproject.toml' found."
     )
     assert str(excinfo.value) == expected_message
 

--- a/tests/test_find_missing_reqs.py
+++ b/tests/test_find_missing_reqs.py
@@ -371,8 +371,40 @@ def test_main_unnamed_requirement(
     expected_code = 2
     assert excinfo.value.code == expected_code
     err = capsys.readouterr().err
-    hint = "Add an '#egg=<name>' fragment naming the distribution."
+    hint = (
+        "Install it, or add an '#egg=<name>' fragment naming the distribution."
+    )
     assert err.endswith(f"error: requirement has no name: {url}. {hint}\n")
+
+
+def test_main_editable_directory_requirement(
+    *,
+    caplog: pytest.LogCaptureFixture,
+    editable_install: EditableInstall,
+    tmp_path: Path,
+) -> None:
+    """An ``-e <directory>`` line satisfies the imports of the install.
+
+    Such a line carries no distribution name, so it previously stopped the
+    check with an error asking for one.
+    """
+    requirements_file = tmp_path / "requirements.txt"
+    requirements_file.write_text(f"-e {editable_install.source_directory}\n")
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    (source_dir / "source.py").write_text(
+        f"import {editable_install.module_name}\n",
+    )
+
+    find_missing_reqs.main(
+        arguments=[
+            "--requirements",
+            str(requirements_file),
+            str(source_dir),
+        ],
+    )
+
+    assert not caplog.records
 
 
 def test_main_egg_fragment_names_requirement(

--- a/tests/test_find_missing_reqs.py
+++ b/tests/test_find_missing_reqs.py
@@ -389,7 +389,10 @@ def test_main_editable_directory_requirement(
     check with an error asking for one.
     """
     requirements_file = tmp_path / "requirements.txt"
-    requirements_file.write_text(f"-e {editable_install.source_directory}\n")
+    # pip splits an editable line as a shell does, so a backslash in a
+    # Windows path is lost. Windows accepts a forward slash instead.
+    directory = editable_install.source_directory.as_posix()
+    requirements_file.write_text(f"-e {directory}\n")
     source_dir = tmp_path / "source"
     source_dir.mkdir()
     (source_dir / "source.py").write_text(


### PR DESCRIPTION
Closes #69

A requirement line such as `-e .` or a bare `git+https://github.com/org/repo.git` carries no distribution name. Both commands stopped with an error asking for an `#egg=<name>` fragment, which is not even applicable to `-e .`, a very common line in a requirements file.

When such a requirement is installed, pip records the directory or URL it came from in `direct_url.json` (PEP 610). The name is now taken from that install:

- a local directory, editable or not, is matched by its resolved path, so `-e .` and `file:///abs/path` both work;
- a version control URL is matched without its `@revision` and `#egg=` fragment, and with its `#subdirectory=` fragment;
- an archive URL is matched as written.

When no such distribution is installed, the error now says to install it or add an `#egg=<name>` fragment.

Also, a requirement which pip refuses to read, such as a directory with no `pyproject.toml` or `setup.py`, is reported as a command line error rather than a pip traceback.

The requirement ignorer now receives the resolved name rather than the parsed requirement, which removes a second `install_req_from_line` call and an `assert` that would have failed for a name learnt from an install.

Tests, README and CHANGELOG updated. Coverage is at 100% and all linters pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes central requirement-name resolution and pip-internal link/VCS matching, which both commands depend on; behavior is well covered by tests but edge cases in URL normalization could still affect matching.
> 
> **Overview**
> **pip-missing-reqs** and **pip-extra-reqs** can now treat common nameless requirement lines—`-e .`, local paths, bare VCS URLs, and archives—as real requirements when a matching package is already installed, instead of failing or crashing.
> 
> Resolution uses each install’s **`direct_url.json`** (PEP 610): directory requirements match on resolved paths (so `-e .` lines up with absolute `file:` URLs in metadata); VCS lines match without `@revision` or `#egg=` but honor `#subdirectory=`; archive URLs match as written. If nothing installed matches, the CLI error now tells users to **install the requirement or add `#egg=<name>`** (replacing the old `AssertionError` / overly strict `#egg`-only message).
> 
> Unparseable requirements (e.g. a directory with no `pyproject.toml`) surface as a single-line **`could not parse requirement`** input error instead of a pip traceback. **`--ignore-requirement`** callbacks now receive the **resolved distribution name** string, avoiding a second parse and broken ignores for install-derived names.
> 
> README and CHANGELOG document the behavior; tests cover directories, relative `-e .`, VCS/archive URLs, and CLI integration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b402aa59ee5f01439bd7a4bd9bd8044aa9bcdea4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->