### PR TITLE
Document --ignore-requirement for pip-extra-reqs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -119,6 +119,25 @@ check by name (or glob pattern) using `--ignore-module` (shorthand is `-m`)::
     pip-missing-reqs --ignore-module=spam --ignore-module=spam.* sample
 
 
+Excluding requirements from the check
+-------------------------------------
+
+A project may need a requirement which its code never imports. A web
+application which lists ``gunicorn`` to serve it, or a plugin which is
+loaded by an entry point, is installed and used without an ``import``
+statement. ``pip-extra-reqs`` reports such a requirement as extra.
+
+You may exclude a requirement from the check by name (or glob pattern) using
+`--ignore-requirement` (shorthand is `-r`). The name is matched as it is
+written in the requirements file. Multiple instances of the option are
+allowed::
+
+    # ignore the requirement gunicorn
+    pip-extra-reqs --ignore-requirement=gunicorn sample
+    # ignore every requirement whose name starts with pytest
+    pip-extra-reqs --ignore-requirement=pytest --ignore-requirement=pytest-* sample
+
+
 Using pyproject.toml instead of requirements.txt
 ------------------------------------------------
 

--- a/tests/test_find_extra_reqs.py
+++ b/tests/test_find_extra_reqs.py
@@ -134,6 +134,82 @@ def test_main_failure(
     assert caplog.records[1].message == expected_message
 
 
+def test_main_ignore_requirement(
+    *,
+    caplog: pytest.LogCaptureFixture,
+    tmp_path: Path,
+) -> None:
+    """A requirement given to ``--ignore-requirement`` is not reported.
+
+    A project may need a requirement which its code never imports, such as
+    a server which runs it, so the option lets a user exclude it by name.
+    """
+    ignored_package = pytest
+    reported_package = pip
+
+    requirements_file = tmp_path / "requirements.txt"
+    requirements_file.write_text(
+        textwrap.dedent(
+            f"""\
+            {ignored_package.__name__}
+            {reported_package.__name__}
+            """,
+        ),
+    )
+
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+
+    caplog.set_level(logging.WARNING)
+
+    with pytest.raises(SystemExit) as excinfo:
+        find_extra_reqs.main(
+            arguments=[
+                "--requirements",
+                str(requirements_file),
+                "--ignore-requirement",
+                ignored_package.__name__,
+                str(source_dir),
+            ],
+        )
+
+    assert excinfo.value.code == 1
+    expected_messages = [
+        "Extra requirements:",
+        f"{reported_package.__name__} in {requirements_file}",
+    ]
+    assert [record.message for record in caplog.records] == expected_messages
+
+
+def test_main_ignore_requirement_glob(
+    *,
+    caplog: pytest.LogCaptureFixture,
+    tmp_path: Path,
+) -> None:
+    """A glob given to ``--ignore-requirement`` matches requirement names."""
+    ignored_package = pytest
+
+    requirements_file = tmp_path / "requirements.txt"
+    requirements_file.write_text(f"{ignored_package.__name__}\n")
+
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+
+    caplog.set_level(logging.WARNING)
+
+    find_extra_reqs.main(
+        arguments=[
+            "--requirements",
+            str(requirements_file),
+            "--ignore-requirement",
+            ignored_package.__name__[:2] + "*",
+            str(source_dir),
+        ],
+    )
+
+    assert not caplog.records
+
+
 def test_main_no_spec(capsys: pytest.CaptureFixture[str]) -> None:
     with pytest.raises(SystemExit) as excinfo:
         find_extra_reqs.main(arguments=[])


### PR DESCRIPTION
Issue #44 asked for a way to whitelist a requirement which a project needs but never imports, such as gunicorn run from a Docker entrypoint. The `--ignore-requirement` option of `pip-extra-reqs` already does this, but the README did not mention it, so the reporter did not find it. This adds a README section "Excluding requirements from the check" with the gunicorn example and a note that globs work. It also adds two command line tests covering an exact name and a glob pattern.

Fixes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and test coverage only; no changes to CLI or filtering logic.
> 
> **Overview**
> Documents the existing **`pip-extra-reqs`** **`--ignore-requirement`** / **`-r`** flag so users can whitelist requirements that are needed but never imported (e.g. **gunicorn**, entry-point plugins). The README adds an **“Excluding requirements from the check”** section with exact-name and glob examples, aligned with the existing **“Excluding modules”** docs.
> 
> Adds two CLI integration tests: one checks that an ignored requirement is omitted from “extra requirements” output while others still fail the check, and one checks that a glob pattern suppresses warnings entirely.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e95f05ebb84a97d0f9d4fcd8a2533dd4b237fb5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->