### PR TITLE
Skip virtual environments within the scanned directory

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,10 @@ Release History
 
 3.1.0
 
+- A virtual environment within the checked directory is now skipped. A
+  directory is treated as a virtual environment when it contains a
+  ``pyvenv.cfg`` file. Both commands previously scanned every installed
+  distribution in such an environment as if it were project source.
 - ``pip-missing-reqs`` accepts ``--requirements-file`` more than once, so
   requirements split across several files are checked as one set.
 - A missing requirements file or source path now reports a concise command

--- a/README.rst
+++ b/README.rst
@@ -111,6 +111,10 @@ don't want this tool to generate false hits for those.
 You may exclude those test files from your check using the `--ignore-file`
 option (shorthand is `-f`). Multiple instances of the option are allowed.
 
+A virtual environment within the checked directory is skipped automatically.
+A directory is treated as a virtual environment when it contains a
+``pyvenv.cfg`` file, which ``venv``, ``virtualenv`` and ``uv`` all create.
+
 
 Excluding modules from the check
 --------------------------------

--- a/pip_check_reqs/common.py
+++ b/pip_check_reqs/common.py
@@ -295,7 +295,22 @@ class _ImportVisitor(ast.NodeVisitor):
         return self._uninstalled
 
 
+def _is_virtual_environment(*, directory: Path) -> bool:
+    """Return whether a directory is the root of a virtual environment.
+
+    The ``venv`` module, ``virtualenv`` and ``uv`` all write a
+    ``pyvenv.cfg`` file at the root of an environment they create.
+    """
+    return (directory / "pyvenv.cfg").is_file()
+
+
 def pyfiles(root: Path) -> Generator[Path, None, None]:
+    """Yield each Python source file within ``root``.
+
+    A virtual environment within ``root`` is skipped. Its files belong to
+    the installed distributions rather than to the project, and scanning
+    them reports every import the environment makes as a use.
+    """
     if not root.exists():
         msg = f"source path not found: {root}"
         raise FileNotFoundError(msg)
@@ -306,9 +321,25 @@ def pyfiles(root: Path) -> Generator[Path, None, None]:
         else:
             msg = f"{root} is not a python file or directory"
             raise ValueError(msg)
-    else:
-        for item in root.rglob("*.py"):
-            yield item.absolute()
+        return
+
+    for dirpath, dirnames, filenames in os.walk(root):
+        directory = Path(dirpath)
+        kept_dirnames: list[str] = []
+        for dirname in sorted(dirnames):
+            if _is_virtual_environment(directory=directory / dirname):
+                log.debug(
+                    "skipping virtual environment: %s",
+                    directory / dirname,
+                )
+                continue
+            kept_dirnames.append(dirname)
+        # Assigning in place prunes the directories ``os.walk`` descends
+        # into.
+        dirnames[:] = kept_dirnames
+        for filename in sorted(filenames):
+            if filename.endswith(".py"):
+                yield (directory / filename).absolute()
 
 
 def validate_requirements_file(*, path: Path) -> None:

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -88,6 +88,53 @@ def test_pyfiles_package(tmp_path: Path) -> None:
     ]
 
 
+def test_pyfiles_skips_virtual_environment(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A virtual environment within the scanned directory is not scanned.
+
+    Its files belong to installed distributions, not to the project.
+    A directory is a virtual environment when it holds a ``pyvenv.cfg``
+    file, which ``venv``, ``virtualenv`` and ``uv`` all write.
+    """
+    python_file = tmp_path / "example.py"
+    python_file.touch()
+
+    venv = tmp_path / "venv"
+    venv.mkdir()
+    (venv / "pyvenv.cfg").touch()
+    venv_python_file = venv / "lib" / "site-packages" / "spam.py"
+    venv_python_file.parent.mkdir(parents=True)
+    venv_python_file.touch()
+
+    # A directory which merely resembles a virtual environment by name is
+    # still scanned.
+    lookalike_python_file = tmp_path / ".venv" / "example.py"
+    lookalike_python_file.parent.mkdir()
+    lookalike_python_file.touch()
+
+    with caplog.at_level(level=logging.DEBUG):
+        found = list(common.pyfiles(root=tmp_path))
+
+    assert found == [python_file, lookalike_python_file]
+    assert f"skipping virtual environment: {venv}" in caplog.text
+
+
+def test_pyfiles_root_is_virtual_environment(tmp_path: Path) -> None:
+    """A virtual environment given directly as the source path is scanned.
+
+    Only environments found within the given path are skipped.
+    """
+    venv = tmp_path / "venv"
+    venv.mkdir()
+    (venv / "pyvenv.cfg").touch()
+    venv_python_file = venv / "spam.py"
+    venv_python_file.touch()
+
+    assert list(common.pyfiles(root=venv)) == [venv_python_file]
+
+
 @pytest.mark.parametrize(
     argnames=("statement", "expected_module_names"),
     argvalues=[


### PR DESCRIPTION
A virtual environment inside the checked directory, such as the `src/env` layout in #128, was walked like project source, so every installed distribution was scanned and `pip-missing-reqs` flooded the output with imports from pip and friends. The file walk now prunes any directory containing a `pyvenv.cfg` file, which venv, virtualenv and uv all write, so detection does not depend on the directory name. A virtual environment passed directly as the source path is still scanned, and skipped directories are logged at debug level. Adds tests for pruning, a name lookalike, and a venv given as the root, plus README and changelog entries under 3.1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)