### PR TITLE
Add --transitive to pip-missing-reqs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,10 @@ Release History
 
 3.1.0
 
+- ``pip-missing-reqs`` gains a ``--transitive`` option. It also reports the
+  dependencies of the distributions the source imports, followed recursively,
+  which no requirements file lists. This checks a constraints file which must
+  pin every distribution in an environment.
 - A virtual environment within the checked directory is now skipped. A
   directory is treated as a virtual environment when it contains a
   ``pyvenv.cfg`` file. Both commands previously scanned every installed

--- a/README.rst
+++ b/README.rst
@@ -148,6 +148,27 @@ allowed::
     pip-extra-reqs --ignore-requirement=pytest --ignore-requirement=pytest-* sample
 
 
+Checking transitive dependencies
+--------------------------------
+
+``pip-missing-reqs`` only looks for the requirements which the source imports.
+A dependency of one of those, which the source does not import itself, need
+not be listed.
+
+Some files must list every distribution, whether the source imports it or
+not. A constraints file, given to pip with ``-c``, which pins a minimum
+version of every distribution in a test environment is one. To check such a
+file, pass `--transitive` (shorthand is `-t`). The dependencies of each
+distribution the source imports are then followed, recursively, and any
+which is not listed is reported with the distribution which requires it::
+
+    pip-missing-reqs --requirements-file=minimum-constraints.txt --transitive sample
+
+A dependency is only followed when its environment marker holds in the
+environment which ``pip-missing-reqs`` runs in, and a dependency of an extra
+is only followed when that extra is asked for.
+
+
 Using pyproject.toml instead of requirements.txt
 ------------------------------------------------
 

--- a/pip_check_reqs/common.py
+++ b/pip_check_reqs/common.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from packaging.markers import Marker
+from packaging.requirements import Requirement
 from packaging.utils import NormalizedName, canonicalize_name
 from pip._internal.commands.show import (
     _PackageInfo,  # pyright: ignore[reportPrivateUsage]
@@ -654,6 +655,78 @@ def used_packages(
         used[canonicalize_name(name)].append(info)
 
     return used
+
+
+def _dependencies(
+    *,
+    distribution: importlib.metadata.Distribution,
+    extras: frozenset[str],
+) -> Iterator[tuple[NormalizedName, frozenset[str]]]:
+    """Yield each distribution which an installed distribution depends on.
+
+    Each dependency is yielded with the extras it is asked for, as
+    ``requests[socks]`` asks for the ``socks`` extra of ``requests``.
+
+    A dependency with an environment marker is only a dependency when the
+    marker holds in this environment, and a dependency of an extra is only
+    a dependency when that extra is asked for.
+    """
+    for requirement_string in distribution.requires or []:
+        requirement = Requirement(requirement_string)
+        if requirement.marker is not None and not any(
+            requirement.marker.evaluate(environment={"extra": extra})
+            for extra in ("", *extras)
+        ):
+            continue
+        yield (
+            canonicalize_name(requirement.name),
+            frozenset(requirement.extras),
+        )
+
+
+def transitive_dependencies(
+    *,
+    names: Iterable[NormalizedName],
+) -> dict[NormalizedName, set[NormalizedName]]:
+    """Map each dependency of ``names`` to the distributions which require it.
+
+    The dependencies are followed recursively, so a dependency of a
+    dependency is included. A distribution which is not installed has no
+    metadata to read, so its dependencies are not followed.
+    """
+    distributions = {
+        canonicalize_name(distribution.metadata["Name"]): distribution
+        for distribution in importlib.metadata.distributions()
+    }
+
+    required_by: dict[NormalizedName, set[NormalizedName]] = {}
+    seen: set[tuple[NormalizedName, frozenset[str]]] = set()
+    to_visit: list[tuple[NormalizedName, frozenset[str]]] = [
+        (name, frozenset()) for name in names
+    ]
+    while to_visit:
+        name, extras = to_visit.pop()
+        if (name, extras) in seen:
+            continue
+        seen.add((name, extras))
+
+        distribution = distributions.get(name)
+        if distribution is None:
+            log.debug(
+                "%s is not installed, so its dependencies are unknown",
+                name,
+            )
+            continue
+
+        for dependency, dependency_extras in _dependencies(
+            distribution=distribution,
+            extras=extras,
+        ):
+            log.debug("%s requires %s", name, dependency)
+            required_by.setdefault(dependency, set()).add(name)
+            to_visit.append((dependency, dependency_extras))
+
+    return required_by
 
 
 def find_required_modules(

--- a/pip_check_reqs/find_missing_reqs.py
+++ b/pip_check_reqs/find_missing_reqs.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import logging
 import sys
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -18,13 +19,32 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 
+@dataclass
+class MissingRequirements:
+    """The requirements which no requirements file lists."""
+
+    used: list[tuple[NormalizedName, list[common.FoundModule]]]
+    """Distributions the source imports, each with the modules it imports."""
+
+    transitive: dict[NormalizedName, set[NormalizedName]] = field(
+        default_factory=dict[NormalizedName, set[NormalizedName]],
+    )
+    """Dependencies of the used distributions, each with the distributions
+    which require it.
+
+    This is only filled when transitive dependencies are checked.
+    """
+
+
 def find_missing_reqs(
     requirements_filename: Path,
     paths: Iterable[Path],
     ignore_files_function: Callable[[str], bool],
     ignore_modules_function: Callable[[str], bool],
     additional_requirements_filenames: Iterable[Path] = (),
-) -> list[tuple[NormalizedName, list[common.FoundModule]]]:
+    *,
+    transitive: bool = False,
+) -> MissingRequirements:
     # 1. find files used by imports in the code (as best we can without
     #    executing)
     imported_modules = common.find_imported_modules(
@@ -54,7 +74,22 @@ def find_missing_reqs(
         explicit=explicit,
     )
 
-    return [(name, used[name]) for name in used if name not in explicit]
+    missing = MissingRequirements(
+        used=[(name, used[name]) for name in used if name not in explicit],
+    )
+    if not transitive:
+        return missing
+
+    # A used distribution is reported with the imports which use it, so we
+    # do not report it a second time as a dependency of another.
+    missing.transitive = {
+        name: required_by
+        for name, required_by in common.transitive_dependencies(
+            names=used,
+        ).items()
+        if name not in explicit and name not in used
+    }
+    return missing
 
 
 def _report_uninstalled_imports(
@@ -83,6 +118,27 @@ def _report_uninstalled_imports(
                 lineno,
                 modname,
             )
+
+
+def _report_missing(*, missing: MissingRequirements) -> None:
+    """Warn about each requirement which no requirements file lists."""
+    log.warning("Missing requirements:")
+    for name, uses in missing.used:
+        for use in uses:
+            for filename, lineno in use.locations:
+                log.warning(
+                    "%s:%s dist=%s module=%s",
+                    filename,
+                    lineno,
+                    name,
+                    use.modname,
+                )
+    for name, required_by in sorted(missing.transitive.items()):
+        log.warning(
+            "dist=%s required by %s",
+            name,
+            ", ".join(sorted(required_by)),
+        )
 
 
 def main(arguments: list[str] | None = None) -> None:
@@ -114,6 +170,17 @@ def main(arguments: list[str] | None = None) -> None:
         action="append",
         default=[],
         help="used module names (globs are ok) to ignore",
+    )
+    parser.add_argument(
+        "-t",
+        "--transitive",
+        dest="transitive",
+        action="store_true",
+        default=False,
+        help=(
+            "also report the dependencies of the used distributions, "
+            "recursively, which are not listed"
+        ),
     )
     parser.add_argument(
         "-v",
@@ -175,6 +242,7 @@ def main(arguments: list[str] | None = None) -> None:
             ignore_files_function=ignore_files,
             ignore_modules_function=ignore_mods,
             additional_requirements_filenames=requirements_filenames[1:],
+            transitive=parse_result.transitive,
         )
     except (OSError, ValueError) as error:
         common.report_input_error(
@@ -183,18 +251,6 @@ def main(arguments: list[str] | None = None) -> None:
             error=error,
         )
 
-    if missing:
-        log.warning("Missing requirements:")
-    for name, uses in missing:
-        for use in uses:
-            for filename, lineno in use.locations:
-                log.warning(
-                    "%s:%s dist=%s module=%s",
-                    filename,
-                    lineno,
-                    name,
-                    use.modname,
-                )
-
-    if missing:
+    if missing.used or missing.transitive:
+        _report_missing(missing=missing)
         sys.exit(1)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ import pytest
 from pip_check_reqs import common
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Iterable, Iterator
     from pathlib import Path
 
 # On Python 3.10, pip reads the environment through ``pkg_resources``, whose
@@ -40,14 +40,21 @@ def write_dist_info(
     site_packages: Path,
     distribution_name: str,
     direct_url: dict[str, object] | None,
+    requires: Iterable[str] = (),
 ) -> None:
-    """Write the ``.dist-info`` directory of an installed distribution."""
+    """Write the ``.dist-info`` directory of an installed distribution.
+
+    ``requires`` gives the dependencies as ``Requires-Dist`` lines.
+    """
     # A ``.dist-info`` directory is named after the normalized distribution
     # name, in which a hyphen is written as an underscore.
     normalized_name = distribution_name.replace("-", "_")
     dist_info = site_packages / f"{normalized_name}-1.0.dist-info"
     dist_info.mkdir(parents=True)
     (dist_info / "INSTALLER").write_text("pip\n", encoding="utf-8")
+    requires_dist = "".join(
+        f"Requires-Dist: {requirement}\n" for requirement in requires
+    )
     (dist_info / "METADATA").write_text(
         textwrap.dedent(
             f"""\
@@ -55,7 +62,8 @@ def write_dist_info(
             Name: {distribution_name}
             Version: 1.0
             """,
-        ),
+        )
+        + requires_dist,
         encoding="utf-8",
     )
     # An editable install records the import hook which pip installed, and
@@ -136,3 +144,83 @@ def editable_install(
     common.get_packages_info.cache_clear()
     common.editable_source_directories.cache_clear()
     common.direct_url_distribution_names.cache_clear()
+
+
+@dataclass(frozen=True)
+class DependencyChain:
+    """Installed distributions which depend on one another.
+
+    The source imports ``top``, which requires ``middle``, which requires
+    the ``fast`` extra of ``bottom`` and a distribution which is not
+    installed. ``bottom`` requires ``top`` in turn, so the chain has a cycle.
+    """
+
+    top: str
+    top_module: str
+    middle: str
+    bottom: str
+    fast: str
+    """A dependency of the ``fast`` extra of ``bottom``."""
+    uninstalled: str
+    """A dependency of ``middle`` which is not installed."""
+    unasked_extra: str
+    """A dependency of an extra of ``top`` which nothing asks for."""
+    incompatible: str
+    """A dependency of ``top`` whose environment marker does not hold."""
+
+
+@pytest.fixture
+def dependency_chain(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Iterator[DependencyChain]:
+    """Install distributions which depend on one another."""
+    chain = DependencyChain(
+        top="top-package-12345",
+        top_module="top_package_12345",
+        middle="middle-package-12345",
+        bottom="bottom-package-12345",
+        fast="fast-package-12345",
+        uninstalled="uninstalled-package-12345",
+        unasked_extra="unasked-extra-package-12345",
+        incompatible="incompatible-package-12345",
+    )
+    site_packages = tmp_path / "chain-site-packages"
+
+    requires = {
+        chain.top: [
+            chain.middle,
+            f'{chain.unasked_extra}; extra == "socks"',
+            f'{chain.incompatible}; python_version < "3"',
+        ],
+        chain.middle: [f"{chain.bottom}[fast]", chain.uninstalled],
+        chain.bottom: [f'{chain.fast}; extra == "fast"', chain.top],
+        chain.fast: [],
+        chain.unasked_extra: [],
+        chain.incompatible: [],
+    }
+    for distribution_name, distribution_requires in requires.items():
+        write_dist_info(
+            site_packages=site_packages,
+            distribution_name=distribution_name,
+            direct_url=None,
+            requires=distribution_requires,
+        )
+
+    # The source imports a module of ``top``, so the install must record
+    # the module file for the import to be attributed to the distribution.
+    module_directory = site_packages / chain.top_module
+    module_directory.mkdir()
+    (module_directory / "__init__.py").touch()
+    record = site_packages / f"{chain.top_module}-1.0.dist-info" / "RECORD"
+    with record.open("a", encoding="utf-8") as record_file:
+        record_file.write(f"{chain.top_module}/__init__.py,,\n")
+
+    monkeypatch.syspath_prepend(  # pyright: ignore[reportUnknownMemberType]
+        str(site_packages),
+    )
+    common.get_packages_info.cache_clear()
+
+    yield chain
+
+    common.get_packages_info.cache_clear()

--- a/tests/test_find_missing_reqs.py
+++ b/tests/test_find_missing_reqs.py
@@ -15,7 +15,7 @@ import pytest
 from pip_check_reqs import common, find_missing_reqs
 
 if TYPE_CHECKING:
-    from .conftest import EditableInstall
+    from .conftest import DependencyChain, EditableInstall
 
 
 def test_find_missing_reqs(tmp_path: Path) -> None:
@@ -67,7 +67,7 @@ def test_find_missing_reqs(tmp_path: Path) -> None:
             ],
         ),
     ]
-    assert result == expected_result
+    assert result.used == expected_result
 
 
 def test_uninstalled_import_is_reported(
@@ -99,7 +99,7 @@ def test_uninstalled_import_is_reported(
         ignore_modules_function=common.ignorer(ignore_cfg=[]),
     )
 
-    assert not result
+    assert not result.used
     expected_message = (
         f"{source_file}:1 module=not_installed_package_12345 is not "
         "installed, so we cannot tell which requirement provides it"
@@ -132,7 +132,7 @@ def test_uninstalled_import_of_requirement_is_not_reported(
         ignore_modules_function=common.ignorer(ignore_cfg=[]),
     )
 
-    assert not result
+    assert not result.used
     assert not caplog.records
 
 
@@ -585,7 +585,7 @@ def test_editable_requirement_is_missing(
         ignore_modules_function=common.ignorer(ignore_cfg=[]),
     )
 
-    (name, uses) = next(iter(result))
+    (name, uses) = next(iter(result.used))
     assert name == editable_install.distribution_name
     assert [use.modname for use in uses] == [editable_install.module_name]
 
@@ -619,4 +619,181 @@ def test_own_source_installed_as_editable_is_not_missing(
         ignore_modules_function=common.ignorer(ignore_cfg=[]),
     )
 
-    assert not result
+    assert not result.used
+
+
+def test_transitive_dependencies_are_reported(
+    *,
+    dependency_chain: DependencyChain,
+    tmp_path: Path,
+) -> None:
+    """Unlisted dependencies of a used distribution are reported.
+
+    They are followed recursively and each is reported with the
+    distributions which require it. A dependency which is not installed is
+    reported but cannot be followed further. A dependency of an extra is
+    only followed when the extra is asked for, and a dependency with an
+    environment marker is only followed when the marker holds.
+    """
+    fake_requirements_file = tmp_path / "requirements.txt"
+    fake_requirements_file.write_text(f"{dependency_chain.top}\n")
+
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    (source_dir / "source.py").write_text(
+        f"import {dependency_chain.top_module}\n",
+    )
+
+    result = find_missing_reqs.find_missing_reqs(
+        requirements_filename=fake_requirements_file,
+        paths=[source_dir],
+        ignore_files_function=common.ignorer(ignore_cfg=[]),
+        ignore_modules_function=common.ignorer(ignore_cfg=[]),
+        transitive=True,
+    )
+
+    assert not result.used
+    assert result.transitive == {
+        dependency_chain.middle: {dependency_chain.top},
+        dependency_chain.bottom: {dependency_chain.middle},
+        dependency_chain.uninstalled: {dependency_chain.middle},
+        dependency_chain.fast: {dependency_chain.bottom},
+    }
+
+
+def test_transitive_dependencies_are_not_checked_by_default(
+    *,
+    dependency_chain: DependencyChain,
+    tmp_path: Path,
+) -> None:
+    fake_requirements_file = tmp_path / "requirements.txt"
+    fake_requirements_file.write_text(f"{dependency_chain.top}\n")
+
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    (source_dir / "source.py").write_text(
+        f"import {dependency_chain.top_module}\n",
+    )
+
+    result = find_missing_reqs.find_missing_reqs(
+        requirements_filename=fake_requirements_file,
+        paths=[source_dir],
+        ignore_files_function=common.ignorer(ignore_cfg=[]),
+        ignore_modules_function=common.ignorer(ignore_cfg=[]),
+    )
+
+    assert not result.used
+    assert not result.transitive
+
+
+def test_listed_transitive_dependencies_are_not_reported(
+    *,
+    dependency_chain: DependencyChain,
+    tmp_path: Path,
+) -> None:
+    fake_requirements_file = tmp_path / "requirements.txt"
+    fake_requirements_file.write_text(
+        textwrap.dedent(
+            f"""\
+            {dependency_chain.top}
+            {dependency_chain.middle}
+            {dependency_chain.bottom}
+            {dependency_chain.fast}
+            {dependency_chain.uninstalled}
+            """,
+        ),
+    )
+
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    (source_dir / "source.py").write_text(
+        f"import {dependency_chain.top_module}\n",
+    )
+
+    result = find_missing_reqs.find_missing_reqs(
+        requirements_filename=fake_requirements_file,
+        paths=[source_dir],
+        ignore_files_function=common.ignorer(ignore_cfg=[]),
+        ignore_modules_function=common.ignorer(ignore_cfg=[]),
+        transitive=True,
+    )
+
+    assert not result.used
+    assert not result.transitive
+
+
+def test_used_distribution_is_not_reported_as_transitive(
+    *,
+    dependency_chain: DependencyChain,
+    tmp_path: Path,
+) -> None:
+    """A used distribution is reported once, with the imports which use it.
+
+    ``bottom`` requires ``top``, which the source imports, so ``top`` is also
+    a transitive dependency. It is reported as a missing requirement of the
+    source and not a second time as a dependency.
+    """
+    fake_requirements_file = tmp_path / "requirements.txt"
+    fake_requirements_file.write_text("")
+
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    (source_dir / "source.py").write_text(
+        f"import {dependency_chain.top_module}\n",
+    )
+
+    result = find_missing_reqs.find_missing_reqs(
+        requirements_filename=fake_requirements_file,
+        paths=[source_dir],
+        ignore_files_function=common.ignorer(ignore_cfg=[]),
+        ignore_modules_function=common.ignorer(ignore_cfg=[]),
+        transitive=True,
+    )
+
+    assert [name for name, _ in result.used] == [dependency_chain.top]
+    assert dependency_chain.top not in result.transitive
+    assert dependency_chain.middle in result.transitive
+
+
+def test_main_transitive(
+    *,
+    dependency_chain: DependencyChain,
+    caplog: pytest.LogCaptureFixture,
+    tmp_path: Path,
+) -> None:
+    """Each unlisted dependency is reported with what requires it."""
+    requirements_file = tmp_path / "requirements.txt"
+    requirements_file.write_text(f"{dependency_chain.top}\n")
+
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    (source_dir / "source.py").write_text(
+        f"import {dependency_chain.top_module}\n",
+    )
+
+    caplog.set_level(logging.WARNING)
+
+    with pytest.raises(SystemExit) as excinfo:
+        find_missing_reqs.main(
+            arguments=[
+                "--requirements-file",
+                str(requirements_file),
+                "--transitive",
+                str(source_dir),
+            ],
+        )
+
+    assert excinfo.value.code == 1
+    assert [record.message for record in caplog.records] == [
+        "Missing requirements:",
+        (
+            f"dist={dependency_chain.bottom} required by "
+            f"{dependency_chain.middle}"
+        ),
+        f"dist={dependency_chain.fast} required by {dependency_chain.bottom}",
+        f"dist={dependency_chain.middle} required by {dependency_chain.top}",
+        (
+            f"dist={dependency_chain.uninstalled} required by "
+            f"{dependency_chain.middle}"
+        ),
+    ]


### PR DESCRIPTION
Closes #170.

`pip-missing-reqs` only checks the distributions which the source imports. A constraints file which must pin every distribution in an environment, direct or not, could not be checked.

With `--transitive` (`-t`), the dependencies of each used distribution are followed recursively through their `Requires-Dist` metadata. Any which no requirements file lists is reported with the distribution which requires it:

```
$ pip-missing-reqs --transitive src
Missing requirements:
dist=certifi required by requests
dist=charset-normalizer required by requests
dist=idna required by requests
dist=urllib3 required by requests
```

- A dependency with an environment marker is only followed when the marker holds in the running environment.
- A dependency of an extra is only followed when that extra is asked for, as `bottom[fast]` asks for it.
- A dependency which is not installed is reported but cannot be followed further.
- A used distribution is reported once, with the imports which use it, even when another distribution also requires it.

`find_missing_reqs` now returns a `MissingRequirements` dataclass with `used` and `transitive` fields instead of a bare list.

Tests use a fixture of fake installed distributions with a dependency chain, including a cycle, an unasked extra and a non-matching marker. All CI checks pass locally, including 100% coverage and Vale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
