### PR TITLE
Keep every path absolute within pyfiles

### DIFF
--- a/pip_check_reqs/common.py
+++ b/pip_check_reqs/common.py
@@ -316,9 +316,13 @@ def pyfiles(root: Path) -> Generator[Path, None, None]:
         msg = f"source path not found: {root}"
         raise FileNotFoundError(msg)
 
+    # We keep every path absolute from here on, so a caller can compare the
+    # files we yield against other absolute paths without converting again.
+    root = root.absolute()
+
     if root.is_file():
         if root.suffix == ".py":
-            yield root.absolute()
+            yield root
         else:
             msg = f"{root} is not a python file or directory"
             raise ValueError(msg)
@@ -340,7 +344,7 @@ def pyfiles(root: Path) -> Generator[Path, None, None]:
         dirnames[:] = kept_dirnames
         for filename in sorted(filenames):
             if filename.endswith(".py"):
-                yield (directory / filename).absolute()
+                yield directory / filename
 
 
 def validate_requirements_file(*, path: Path) -> None:


### PR DESCRIPTION
Part of #97, the "ensure all paths are kept as absolute" item.

`pyfiles` now makes its root absolute once, right after the existence check, instead of calling `.absolute()` on each yielded file. The walk then runs over an absolute root, so every yielded path is already absolute. Behaviour is unchanged, so there is no changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)