### PR TITLE
Match ignored files as paths rather than strings

### DIFF
--- a/pip_check_reqs/common.py
+++ b/pip_check_reqs/common.py
@@ -395,7 +395,7 @@ def source_module_names(*, paths: Iterable[Path]) -> set[str]:
 def find_imported_modules(
     *,
     paths: Iterable[Path],
-    ignore_files_function: Callable[[str], bool],
+    ignore_files_function: Callable[[Path], bool],
     ignore_modules_function: Callable[[str], bool],
 ) -> ImportedModules:
     # We take the names the source provides before scanning, as an ignored
@@ -405,7 +405,7 @@ def find_imported_modules(
     vis = _ImportVisitor(ignore_modules_function=ignore_modules_function)
     for path in paths:
         for filename in pyfiles(path):
-            if ignore_files_function(str(filename)):
+            if ignore_files_function(filename):
                 log.info("ignoring: %s", filename)
                 continue
             log.debug("scanning: %s", filename)
@@ -803,42 +803,57 @@ def package_path(*, path: Path) -> Path | None:
     return path.parent
 
 
-def _null_ignorer(_: str) -> bool:
+def _null_ignorer(_: object) -> bool:
     return False
 
 
 def ignorer(*, ignore_cfg: list[str]) -> Callable[[str], bool]:
+    """Return a function which tells whether a name matches an ignore glob.
+
+    The name is a module or distribution name.
+    """
     if not ignore_cfg:
         return _null_ignorer
 
-    def ignorer_function(
-        candidate_path: str,
-        ignore_cfg: list[str] = ignore_cfg,
-    ) -> bool:
-        working_directory = Path.cwd()
-        for ignore in ignore_cfg:
-            if fnmatch.fnmatch(candidate_path, ignore):
-                return True
+    def ignorer_function(candidate: str) -> bool:
+        return any(fnmatch.fnmatch(candidate, ignore) for ignore in ignore_cfg)
 
-            # Files are given as absolute paths, while an ignore glob is
-            # usually written relative to the working directory, so we match
-            # against the relative path as well.
-            # A path may contain ``..``, for example when the source to scan
-            # was given as ``scripts/../src``, so we normalize it before
-            # comparing.
-            # We use ``Path`` rather than ``os.path.relpath``, which raises
-            # ``ValueError`` on Windows for a path on a different drive to the
-            # working directory.
-            absolute_candidate = Path(
-                os.path.normpath(working_directory / candidate_path),
+    return ignorer_function
+
+
+def file_ignorer(*, ignore_cfg: list[str]) -> Callable[[Path], bool]:
+    """Return a function which tells whether a file matches an ignore glob.
+
+    A glob is matched against the path as given, and against the path
+    relative to the working directory.
+    """
+    if not ignore_cfg:
+        return _null_ignorer
+
+    def ignorer_function(candidate_path: Path) -> bool:
+        working_directory = Path.cwd()
+        # Files are given as absolute paths, while an ignore glob is usually
+        # written relative to the working directory, so we match against the
+        # relative path as well.
+        # A path may contain ``..``, for example when the source to scan was
+        # given as ``scripts/../src``, so we normalize it before comparing.
+        # We use ``Path`` rather than ``os.path.relpath``, which raises
+        # ``ValueError`` on Windows for a path on a different drive to the
+        # working directory.
+        absolute_candidate = Path(
+            os.path.normpath(working_directory / candidate_path),
+        )
+        candidates = [str(candidate_path)]
+        if absolute_candidate.is_relative_to(working_directory):
+            relative_candidate = absolute_candidate.relative_to(
+                working_directory,
             )
-            if absolute_candidate.is_relative_to(working_directory):
-                relative_candidate = absolute_candidate.relative_to(
-                    working_directory,
-                )
-                if fnmatch.fnmatch(str(relative_candidate), ignore):
-                    return True
-        return False
+            candidates.append(str(relative_candidate))
+        return any(
+            fnmatch.fnmatch(candidate, ignore)
+            for candidate in candidates
+            for ignore in ignore_cfg
+        )
 
     return ignorer_function
 

--- a/pip_check_reqs/find_extra_reqs.py
+++ b/pip_check_reqs/find_extra_reqs.py
@@ -20,7 +20,7 @@ def find_extra_reqs(
     *,
     requirements_filename: Path,
     paths: Iterable[Path],
-    ignore_files_function: Callable[[str], bool],
+    ignore_files_function: Callable[[Path], bool],
     ignore_modules_function: Callable[[str], bool],
     ignore_requirements_function: Callable[[str], bool],
     skip_incompatible: bool,
@@ -145,7 +145,9 @@ def main(arguments: list[str] | None = None) -> None:
     if not parse_result.paths:
         parser.error("no source files or directories specified")
 
-    ignore_files = common.ignorer(ignore_cfg=parse_result.ignore_files)
+    ignore_files = common.file_ignorer(
+        ignore_cfg=parse_result.ignore_files,
+    )
     ignore_mods = common.ignorer(ignore_cfg=parse_result.ignore_mods)
     ignore_reqs = common.ignorer(ignore_cfg=parse_result.ignore_reqs)
 

--- a/pip_check_reqs/find_missing_reqs.py
+++ b/pip_check_reqs/find_missing_reqs.py
@@ -39,7 +39,7 @@ class MissingRequirements:
 def find_missing_reqs(
     requirements_filename: Path,
     paths: Iterable[Path],
-    ignore_files_function: Callable[[str], bool],
+    ignore_files_function: Callable[[Path], bool],
     ignore_modules_function: Callable[[str], bool],
     additional_requirements_filenames: Iterable[Path] = (),
     *,
@@ -219,7 +219,9 @@ def main(arguments: list[str] | None = None) -> None:
     requirements_filenames = parse_result.requirements_filenames or [
         Path("requirements.txt"),
     ]
-    ignore_files = common.ignorer(ignore_cfg=parse_result.ignore_files)
+    ignore_files = common.file_ignorer(
+        ignore_cfg=parse_result.ignore_files,
+    )
     ignore_mods = common.ignorer(ignore_cfg=parse_result.ignore_mods)
 
     logging.basicConfig(format="%(message)s")

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -170,7 +170,7 @@ def test_find_imported_modules_simple(
 
     result = common.find_imported_modules(
         paths=[tmp_path],
-        ignore_files_function=common.ignorer(ignore_cfg=[]),
+        ignore_files_function=common.file_ignorer(ignore_cfg=[]),
         ignore_modules_function=common.ignorer(ignore_cfg=[]),
     ).found
 
@@ -209,7 +209,7 @@ def test_find_imported_modules_frozen(
 
     result = common.find_imported_modules(
         paths=[tmp_path],
-        ignore_files_function=common.ignorer(ignore_cfg=[]),
+        ignore_files_function=common.file_ignorer(ignore_cfg=[]),
         ignore_modules_function=common.ignorer(ignore_cfg=[]),
     ).found
 
@@ -229,7 +229,7 @@ def test_find_imported_modules_built_in(
 
     result = common.find_imported_modules(
         paths=[tmp_path],
-        ignore_files_function=common.ignorer(ignore_cfg=[]),
+        ignore_files_function=common.file_ignorer(ignore_cfg=[]),
         ignore_modules_function=common.ignorer(ignore_cfg=[]),
     ).found
 
@@ -259,7 +259,7 @@ def test_find_imported_modules_main(
 
     result = common.find_imported_modules(
         paths=[tmp_path],
-        ignore_files_function=common.ignorer(ignore_cfg=[]),
+        ignore_files_function=common.file_ignorer(ignore_cfg=[]),
         ignore_modules_function=common.ignorer(ignore_cfg=[]),
     ).found
 
@@ -287,7 +287,7 @@ def test_find_imported_modules_no_spec(tmp_path: Path) -> None:
     try:
         result = common.find_imported_modules(
             paths=[tmp_path],
-            ignore_files_function=common.ignorer(ignore_cfg=[]),
+            ignore_files_function=common.file_ignorer(ignore_cfg=[]),
             ignore_modules_function=common.ignorer(ignore_cfg=[]),
         ).found
     finally:
@@ -315,7 +315,7 @@ def test_find_imported_modules_syntax_error(tmp_path: Path) -> None:
     ):
         common.find_imported_modules(
             paths=[tmp_path],
-            ignore_files_function=common.ignorer(ignore_cfg=[]),
+            ignore_files_function=common.file_ignorer(ignore_cfg=[]),
             ignore_modules_function=common.ignorer(ignore_cfg=[]),
         )
 
@@ -334,7 +334,7 @@ def test_find_imported_modules_period(tmp_path: Path) -> None:
 
     result = common.find_imported_modules(
         paths=[tmp_path],
-        ignore_files_function=common.ignorer(ignore_cfg=[]),
+        ignore_files_function=common.file_ignorer(ignore_cfg=[]),
         ignore_modules_function=common.ignorer(ignore_cfg=[]),
     ).found
 
@@ -361,7 +361,7 @@ def test_find_imported_modules_missing_from_submodule(
 
     result = common.find_imported_modules(
         paths=[source_dir],
-        ignore_files_function=common.ignorer(ignore_cfg=[]),
+        ignore_files_function=common.file_ignorer(ignore_cfg=[]),
         ignore_modules_function=common.ignorer(ignore_cfg=[]),
     ).found
 
@@ -422,8 +422,8 @@ def test_find_imported_modules_advanced(
 
     caplog.set_level(logging.INFO)
 
-    def ignore_files(path: str) -> bool:
-        return bool(Path(path).name == "ham.py" and ignore_ham)
+    def ignore_files(path: Path) -> bool:
+        return bool(path.name == "ham.py" and ignore_ham)
 
     def ignore_mods(module: str) -> bool:
         return bool(module == "hashlib" and ignore_hashlib)
@@ -463,7 +463,7 @@ def test_find_imported_modules_uninstalled(tmp_path: Path) -> None:
 
     result = common.find_imported_modules(
         paths=[source_dir],
-        ignore_files_function=common.ignorer(ignore_cfg=[]),
+        ignore_files_function=common.file_ignorer(ignore_cfg=[]),
         ignore_modules_function=common.ignorer(ignore_cfg=[]),
     )
 
@@ -502,7 +502,7 @@ def test_find_imported_modules_uninstalled_ignored(
 
     result = common.find_imported_modules(
         paths=[source_dir],
-        ignore_files_function=common.ignorer(ignore_cfg=[]),
+        ignore_files_function=common.file_ignorer(ignore_cfg=[]),
         ignore_modules_function=common.ignorer(
             ignore_cfg=[ignore_glob.format(name=name)],
         ),
@@ -528,7 +528,7 @@ def test_find_imported_modules_uninstalled_no_spec(tmp_path: Path) -> None:
     try:
         result = common.find_imported_modules(
             paths=[source_dir],
-            ignore_files_function=common.ignorer(ignore_cfg=[]),
+            ignore_files_function=common.file_ignorer(ignore_cfg=[]),
             ignore_modules_function=common.ignorer(ignore_cfg=[]),
         )
     finally:
@@ -556,7 +556,7 @@ def test_find_imported_modules_uninstalled_submodule(tmp_path: Path) -> None:
 
     result = common.find_imported_modules(
         paths=[source_dir],
-        ignore_files_function=common.ignorer(ignore_cfg=[]),
+        ignore_files_function=common.file_ignorer(ignore_cfg=[]),
         ignore_modules_function=common.ignorer(ignore_cfg=[]),
     )
 
@@ -608,7 +608,7 @@ def test_find_imported_modules_uninstalled_optional(
 
     result = common.find_imported_modules(
         paths=[source_dir],
-        ignore_files_function=common.ignorer(ignore_cfg=[]),
+        ignore_files_function=common.file_ignorer(ignore_cfg=[]),
         ignore_modules_function=common.ignorer(ignore_cfg=[]),
     )
 
@@ -686,7 +686,7 @@ def test_find_imported_modules_uninstalled_not_optional(
 
     result = common.find_imported_modules(
         paths=[source_dir],
-        ignore_files_function=common.ignorer(ignore_cfg=[]),
+        ignore_files_function=common.file_ignorer(ignore_cfg=[]),
         ignore_modules_function=common.ignorer(ignore_cfg=[]),
     )
 
@@ -714,7 +714,7 @@ def test_find_imported_modules_optional_installed(tmp_path: Path) -> None:
 
     result = common.find_imported_modules(
         paths=[source_dir],
-        ignore_files_function=common.ignorer(ignore_cfg=[]),
+        ignore_files_function=common.file_ignorer(ignore_cfg=[]),
         ignore_modules_function=common.ignorer(ignore_cfg=[]),
     )
 
@@ -752,7 +752,9 @@ def test_find_imported_modules_source_module(
 
     result = common.find_imported_modules(
         paths=[source_dir],
-        ignore_files_function=common.ignorer(ignore_cfg=["*ignored.py"]),
+        ignore_files_function=common.file_ignorer(
+            ignore_cfg=["*ignored.py"],
+        ),
         ignore_modules_function=common.ignorer(ignore_cfg=[]),
     )
 
@@ -780,11 +782,6 @@ def test_source_module_names_file(tmp_path: Path) -> None:
         (["spam*"], "spam", True),
         (["spam*"], "spam.ham", True),
         (["spam*"], "eggs", False),
-        (["spam"], str(Path.cwd() / "spam"), True),
-        (["eggs"], str(Path.cwd() / "spam"), False),
-        (["spam"], str(Path.cwd() / "eggs" / ".." / "spam"), True),
-        (["spam"], str(Path("eggs") / ".." / "spam"), True),
-        (["spam"], str(Path.cwd().parent / "spam"), False),
     ],
 )
 def test_ignorer(
@@ -794,6 +791,30 @@ def test_ignorer(
     result: bool,
 ) -> None:
     ignorer = common.ignorer(ignore_cfg=ignore_cfg)
+    assert ignorer(candidate) == result
+
+
+@pytest.mark.parametrize(
+    ("ignore_cfg", "candidate", "result"),
+    [
+        ([], Path("spam"), False),
+        (["spam"], Path("spam"), True),
+        (["spam"], Path("eggs"), False),
+        (["spam*"], Path("spam.py"), True),
+        (["spam"], Path.cwd() / "spam", True),
+        (["eggs"], Path.cwd() / "spam", False),
+        (["spam"], Path.cwd() / "eggs" / ".." / "spam", True),
+        (["spam"], Path("eggs") / ".." / "spam", True),
+        (["spam"], Path.cwd().parent / "spam", False),
+    ],
+)
+def test_file_ignorer(
+    *,
+    ignore_cfg: list[str],
+    candidate: Path,
+    result: bool,
+) -> None:
+    ignorer = common.file_ignorer(ignore_cfg=ignore_cfg)
     assert ignorer(candidate) == result
 
 
@@ -809,9 +830,9 @@ def test_ignorer_other_drive() -> None:  # pragma: no cover
     """
     working_directory_drive = Path.cwd().drive
     other_drive = "Y:" if working_directory_drive.upper() == "Z:" else "Z:"
-    ignorer = common.ignorer(ignore_cfg=["eggs"])
+    ignorer = common.file_ignorer(ignore_cfg=["eggs"])
 
-    assert not ignorer(rf"{other_drive}\eggs\spam.py")
+    assert not ignorer(Path(rf"{other_drive}\eggs\spam.py"))
 
 
 def test_find_required_modules(tmp_path: Path) -> None:

--- a/tests/test_find_extra_reqs.py
+++ b/tests/test_find_extra_reqs.py
@@ -50,7 +50,7 @@ def test_find_extra_reqs(tmp_path: Path) -> None:
     result = find_extra_reqs.find_extra_reqs(
         requirements_filename=fake_requirements_file,
         paths=[source_dir],
-        ignore_files_function=common.ignorer(ignore_cfg=[]),
+        ignore_files_function=common.file_ignorer(ignore_cfg=[]),
         ignore_modules_function=common.ignorer(ignore_cfg=[]),
         ignore_requirements_function=common.ignorer(ignore_cfg=[]),
         skip_incompatible=False,
@@ -84,7 +84,7 @@ def test_uninstalled_requirement_is_not_extra(
     result = find_extra_reqs.find_extra_reqs(
         requirements_filename=fake_requirements_file,
         paths=[source_dir],
-        ignore_files_function=common.ignorer(ignore_cfg=[]),
+        ignore_files_function=common.file_ignorer(ignore_cfg=[]),
         ignore_modules_function=common.ignorer(ignore_cfg=[]),
         ignore_requirements_function=common.ignorer(ignore_cfg=[]),
         skip_incompatible=False,
@@ -449,7 +449,7 @@ def test_editable_requirement_is_not_extra(
     result = find_extra_reqs.find_extra_reqs(
         requirements_filename=fake_requirements_file,
         paths=[source_dir],
-        ignore_files_function=common.ignorer(ignore_cfg=[]),
+        ignore_files_function=common.file_ignorer(ignore_cfg=[]),
         ignore_modules_function=common.ignorer(ignore_cfg=[]),
         ignore_requirements_function=common.ignorer(ignore_cfg=[]),
         skip_incompatible=False,
@@ -477,7 +477,7 @@ def test_editable_requirement_not_imported_is_extra(
     result = find_extra_reqs.find_extra_reqs(
         requirements_filename=fake_requirements_file,
         paths=[source_dir],
-        ignore_files_function=common.ignorer(ignore_cfg=[]),
+        ignore_files_function=common.file_ignorer(ignore_cfg=[]),
         ignore_modules_function=common.ignorer(ignore_cfg=[]),
         ignore_requirements_function=common.ignorer(ignore_cfg=[]),
         skip_incompatible=False,

--- a/tests/test_find_missing_reqs.py
+++ b/tests/test_find_missing_reqs.py
@@ -50,7 +50,7 @@ def test_find_missing_reqs(tmp_path: Path) -> None:
     result = find_missing_reqs.find_missing_reqs(
         requirements_filename=fake_requirements_file,
         paths=[source_dir],
-        ignore_files_function=common.ignorer(ignore_cfg=[]),
+        ignore_files_function=common.file_ignorer(ignore_cfg=[]),
         ignore_modules_function=common.ignorer(ignore_cfg=[]),
     )
     expected_result = [
@@ -95,7 +95,7 @@ def test_uninstalled_import_is_reported(
     result = find_missing_reqs.find_missing_reqs(
         requirements_filename=fake_requirements_file,
         paths=[source_dir],
-        ignore_files_function=common.ignorer(ignore_cfg=[]),
+        ignore_files_function=common.file_ignorer(ignore_cfg=[]),
         ignore_modules_function=common.ignorer(ignore_cfg=[]),
     )
 
@@ -128,7 +128,7 @@ def test_uninstalled_import_of_requirement_is_not_reported(
     result = find_missing_reqs.find_missing_reqs(
         requirements_filename=fake_requirements_file,
         paths=[source_dir],
-        ignore_files_function=common.ignorer(ignore_cfg=[]),
+        ignore_files_function=common.file_ignorer(ignore_cfg=[]),
         ignore_modules_function=common.ignorer(ignore_cfg=[]),
     )
 
@@ -581,7 +581,7 @@ def test_editable_requirement_is_missing(
     result = find_missing_reqs.find_missing_reqs(
         requirements_filename=fake_requirements_file,
         paths=[source_dir],
-        ignore_files_function=common.ignorer(ignore_cfg=[]),
+        ignore_files_function=common.file_ignorer(ignore_cfg=[]),
         ignore_modules_function=common.ignorer(ignore_cfg=[]),
     )
 
@@ -615,7 +615,7 @@ def test_own_source_installed_as_editable_is_not_missing(
     result = find_missing_reqs.find_missing_reqs(
         requirements_filename=fake_requirements_file,
         paths=[editable_install.source_directory],
-        ignore_files_function=common.ignorer(ignore_cfg=[]),
+        ignore_files_function=common.file_ignorer(ignore_cfg=[]),
         ignore_modules_function=common.ignorer(ignore_cfg=[]),
     )
 
@@ -647,7 +647,7 @@ def test_transitive_dependencies_are_reported(
     result = find_missing_reqs.find_missing_reqs(
         requirements_filename=fake_requirements_file,
         paths=[source_dir],
-        ignore_files_function=common.ignorer(ignore_cfg=[]),
+        ignore_files_function=common.file_ignorer(ignore_cfg=[]),
         ignore_modules_function=common.ignorer(ignore_cfg=[]),
         transitive=True,
     )
@@ -678,7 +678,7 @@ def test_transitive_dependencies_are_not_checked_by_default(
     result = find_missing_reqs.find_missing_reqs(
         requirements_filename=fake_requirements_file,
         paths=[source_dir],
-        ignore_files_function=common.ignorer(ignore_cfg=[]),
+        ignore_files_function=common.file_ignorer(ignore_cfg=[]),
         ignore_modules_function=common.ignorer(ignore_cfg=[]),
     )
 
@@ -713,7 +713,7 @@ def test_listed_transitive_dependencies_are_not_reported(
     result = find_missing_reqs.find_missing_reqs(
         requirements_filename=fake_requirements_file,
         paths=[source_dir],
-        ignore_files_function=common.ignorer(ignore_cfg=[]),
+        ignore_files_function=common.file_ignorer(ignore_cfg=[]),
         ignore_modules_function=common.ignorer(ignore_cfg=[]),
         transitive=True,
     )
@@ -745,7 +745,7 @@ def test_used_distribution_is_not_reported_as_transitive(
     result = find_missing_reqs.find_missing_reqs(
         requirements_filename=fake_requirements_file,
         paths=[source_dir],
-        ignore_files_function=common.ignorer(ignore_cfg=[]),
+        ignore_files_function=common.file_ignorer(ignore_cfg=[]),
         ignore_modules_function=common.ignorer(ignore_cfg=[]),
         transitive=True,
     )


### PR DESCRIPTION
Part of #97 (use `pathlib.Path` instead of `os.path`).

The shared `ignorer` was used for files, module names and distribution names alike, so file paths were converted to strings before matching and names went through the working directory logic which only makes sense for files.

This splits it in two: `ignorer` matches a name against the globs, and the new `file_ignorer` takes a `Path` and also matches the path relative to the working directory. `find_imported_modules` and the two commands now type the file ignorer as `Callable[[Path], bool]`.

No behaviour change for users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)