### PR TITLE
Re-enable pylint's deprecated-module check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,8 +104,6 @@ lint.unfixable = [
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
 "MESSAGES CONTROL".disable = [
-  # We will remove this in issue 97
-  "deprecated-module",
   # Too difficult to please
   "duplicate-code",
   # Let ruff handle long lines


### PR DESCRIPTION
The check was disabled with a note pointing at #97 while \`optparse\` and \`imp\` were still in use. Both are gone, and pylint passes with the check on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)