### PR TITLE
Test a distribution installed in an environment under the working directory

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -151,6 +151,59 @@ def editable_install(
 
 
 @dataclass(frozen=True)
+class NestedInstall:
+    """A distribution installed under the working directory."""
+
+    distribution_name: str
+    module_name: str
+
+
+@pytest.fixture
+def nested_install(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Iterator[NestedInstall]:
+    """Install a distribution in an environment inside the working directory.
+
+    A virtual environment is often created inside the project directory, as
+    ``python -m venv env`` or ``tox`` does, and the commands are run from the
+    project directory. The files of an installed distribution used to be
+    made relative to the working directory and then joined to the
+    distribution location again, which doubled the path to the environment,
+    so no import was attributed to a distribution installed there.
+    """
+    distribution_name = "nested-package-12345"
+    module_name = "nested_package_12345"
+
+    site_packages = tmp_path / "env" / "lib" / "site-packages"
+    write_dist_info(
+        site_packages=site_packages,
+        distribution_name=distribution_name,
+        direct_url=None,
+    )
+    module_file = site_packages / f"{module_name}.py"
+    module_file.touch()
+    record = site_packages / f"{module_name}-1.0.dist-info" / "RECORD"
+    with record.open("a", encoding="utf-8") as record_file:
+        record_file.write(f"{module_file.name},,\n")
+
+    monkeypatch.chdir(tmp_path)
+    # The parameter has no annotation until
+    # https://github.com/pytest-dev/pytest/pull/14988 is released.
+    monkeypatch.syspath_prepend(  # pyright: ignore[reportUnknownMemberType]
+        str(site_packages),
+    )
+    common.get_packages_info.cache_clear()
+
+    yield NestedInstall(
+        distribution_name=distribution_name,
+        module_name=module_name,
+    )
+
+    common.get_packages_info.cache_clear()
+
+
+@dataclass(frozen=True)
 class DependencyChain:
     """Installed distributions which depend on one another.
 

--- a/tests/test_find_extra_reqs.py
+++ b/tests/test_find_extra_reqs.py
@@ -15,7 +15,7 @@ import pytest
 from pip_check_reqs import common, find_extra_reqs
 
 if TYPE_CHECKING:
-    from .conftest import EditableInstall
+    from .conftest import EditableInstall, NestedInstall
 
 
 def test_find_extra_reqs(tmp_path: Path) -> None:
@@ -484,3 +484,37 @@ def test_editable_requirement_not_imported_is_extra(
     )
 
     assert result == [editable_install.distribution_name]
+
+
+def test_requirement_installed_within_working_directory_is_not_extra(
+    *,
+    nested_install: NestedInstall,
+    tmp_path: Path,
+) -> None:
+    """A requirement imported from a nested environment is not extra.
+
+    The environment is inside the working directory, as when it is created
+    with ``python -m venv env`` in the project directory.
+
+    See https://github.com/adamtheturtle/pip-check-reqs/issues/75.
+    """
+    fake_requirements_file = tmp_path / "requirements.txt"
+    fake_requirements_file.write_text(
+        nested_install.distribution_name + "\n",
+    )
+
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    source_file = source_dir / "source.py"
+    source_file.write_text(f"import {nested_install.module_name}\n")
+
+    result = find_extra_reqs.find_extra_reqs(
+        requirements_filename=fake_requirements_file,
+        paths=[source_dir],
+        ignore_files_function=common.file_ignorer(ignore_cfg=[]),
+        ignore_modules_function=common.ignorer(ignore_cfg=[]),
+        ignore_requirements_function=common.ignorer(ignore_cfg=[]),
+        skip_incompatible=False,
+    )
+
+    assert not result

--- a/tests/test_find_missing_reqs.py
+++ b/tests/test_find_missing_reqs.py
@@ -15,7 +15,7 @@ import pytest
 from pip_check_reqs import common, find_missing_reqs
 
 if TYPE_CHECKING:
-    from .conftest import DependencyChain, EditableInstall
+    from .conftest import DependencyChain, EditableInstall, NestedInstall
 
 
 def test_find_missing_reqs(tmp_path: Path) -> None:
@@ -797,3 +797,35 @@ def test_main_transitive(
             f"{dependency_chain.middle}"
         ),
     ]
+
+
+def test_import_installed_within_working_directory_is_missing(
+    *,
+    nested_install: NestedInstall,
+    tmp_path: Path,
+) -> None:
+    """An unlisted import from a nested environment is reported.
+
+    The environment is inside the working directory, as when it is created
+    with ``python -m venv env`` in the project directory.
+
+    See https://github.com/adamtheturtle/pip-check-reqs/issues/75.
+    """
+    fake_requirements_file = tmp_path / "requirements.txt"
+    fake_requirements_file.write_text("")
+
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    source_file = source_dir / "source.py"
+    source_file.write_text(f"import {nested_install.module_name}\n")
+
+    result = find_missing_reqs.find_missing_reqs(
+        requirements_filename=fake_requirements_file,
+        paths=[source_dir],
+        ignore_files_function=common.file_ignorer(ignore_cfg=[]),
+        ignore_modules_function=common.ignorer(ignore_cfg=[]),
+    )
+
+    (name, uses) = next(iter(result.used))
+    assert name == nested_install.distribution_name
+    assert [use.modname for use in uses] == [nested_install.module_name]


### PR DESCRIPTION
Issue #75 reported every requirement as extra when the virtual environment sat inside the project directory, because each installed file path was made relative to the working directory and then joined to the package location again. That was fixed in #505 without a regression test. This adds a `nested_install` fixture which installs a distribution in an environment under the working directory, plus a test for each command: `pip-extra-reqs` does not report a listed requirement imported from it, and `pip-missing-reqs` reports an unlisted one. Both tests fail against the pre-#505 logic and pass now.

Fixes #75.

🤖 Generated with [Claude Code](https://claude.com/claude-code)