### PR TITLE
Walk the source tree with pathlib rather than os.walk

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,9 @@ Release History
 
 3.1.0
 
+- A directory within the checked path which cannot be read now reports a
+  command line error. It was previously skipped silently, which hid any
+  missing requirement imported only by the files within it.
 - ``pip-missing-reqs`` gains a ``--transitive`` option. It also reports the
   dependencies of the distributions the source imports, followed recursively,
   which no requirements file lists. This checks a constraints file which must

--- a/pip_check_reqs/common.py
+++ b/pip_check_reqs/common.py
@@ -328,23 +328,29 @@ def pyfiles(root: Path) -> Generator[Path, None, None]:
             raise ValueError(msg)
         return
 
-    for dirpath, dirnames, filenames in os.walk(root):
-        directory = Path(dirpath)
-        kept_dirnames: list[str] = []
-        for dirname in sorted(dirnames):
-            if _is_virtual_environment(directory=directory / dirname):
-                log.debug(
-                    "skipping virtual environment: %s",
-                    directory / dirname,
-                )
-                continue
-            kept_dirnames.append(dirname)
-        # Assigning in place prunes the directories ``os.walk`` descends
-        # into.
-        dirnames[:] = kept_dirnames
-        for filename in sorted(filenames):
-            if filename.endswith(".py"):
-                yield directory / filename
+    yield from _pyfiles_in_directory(directory=root)
+
+
+def _pyfiles_in_directory(directory: Path) -> Generator[Path, None, None]:
+    """Yield each Python source file within a directory, recursively.
+
+    The files directly within the directory come before those within the
+    directories beneath it, and each group is in name order, so the output
+    is stable across file systems which list entries differently.
+    """
+    entries = sorted(directory.iterdir())
+    for entry in entries:
+        if entry.is_file() and entry.name.endswith(".py"):
+            yield entry
+    for entry in entries:
+        # A symbolic link to a directory is not descended into, as a link
+        # back to a parent directory would be followed forever.
+        if not entry.is_dir() or entry.is_symlink():
+            continue
+        if _is_virtual_environment(directory=entry):
+            log.debug("skipping virtual environment: %s", entry)
+            continue
+        yield from _pyfiles_in_directory(directory=entry)
 
 
 def validate_requirements_file(*, path: Path) -> None:

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -160,11 +160,15 @@ def test_pyfiles_unreadable_directory(tmp_path: Path) -> None:
     try:
         # File mode bits do not restrict reading a directory on Windows, and
         # the superuser can read a directory regardless of its mode.
+        # Coverage is measured on Windows too, so the lines only one of
+        # these platforms runs are excluded from it.
         if os.access(unreadable, os.R_OK):
             pytest.skip(  # pragma: no cover
                 reason="This user can read a directory with mode 0",
             )
-        with pytest.raises(expected_exception=PermissionError):
+        with pytest.raises(  # pragma: no cover
+            expected_exception=PermissionError,
+        ):
             list(common.pyfiles(root=tmp_path))
     finally:
         unreadable.chmod(mode=0o755)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -147,9 +147,7 @@ def test_pyfiles_does_not_follow_directory_symlink(tmp_path: Path) -> None:
     ]
 
 
-def test_pyfiles_unreadable_directory(
-    tmp_path: Path,
-) -> None:  # pragma: no cover
+def test_pyfiles_unreadable_directory(tmp_path: Path) -> None:
     """A directory which cannot be read raises an error.
 
     Skipping it silently would hide any missing requirement which only its
@@ -163,7 +161,9 @@ def test_pyfiles_unreadable_directory(
         # File mode bits do not restrict reading a directory on Windows, and
         # the superuser can read a directory regardless of its mode.
         if os.access(unreadable, os.R_OK):
-            pytest.skip(reason="This user can read a directory with mode 0")
+            pytest.skip(  # pragma: no cover
+                reason="This user can read a directory with mode 0",
+            )
         with pytest.raises(expected_exception=PermissionError):
             list(common.pyfiles(root=tmp_path))
     finally:

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import platform
 import re
 import sys
@@ -144,6 +145,29 @@ def test_pyfiles_does_not_follow_directory_symlink(tmp_path: Path) -> None:
         python_file,
         linked_directory / "spam.py",
     ]
+
+
+def test_pyfiles_unreadable_directory(
+    tmp_path: Path,
+) -> None:  # pragma: no cover
+    """A directory which cannot be read raises an error.
+
+    Skipping it silently would hide any missing requirement which only its
+    files import.
+    """
+    unreadable = tmp_path / "unreadable"
+    unreadable.mkdir()
+    (unreadable / "spam.py").touch()
+    unreadable.chmod(mode=0)
+    try:
+        # File mode bits do not restrict reading a directory on Windows, and
+        # the superuser can read a directory regardless of its mode.
+        if os.access(unreadable, os.R_OK):
+            pytest.skip(reason="This user can read a directory with mode 0")
+        with pytest.raises(expected_exception=PermissionError):
+            list(common.pyfiles(root=tmp_path))
+    finally:
+        unreadable.chmod(mode=0o755)
 
 
 def test_pyfiles_root_is_virtual_environment(tmp_path: Path) -> None:


### PR DESCRIPTION
Replace the `os.walk` loop in `pyfiles` with a recursive `pathlib` walk. This is part of the "use `pathlib.Path` instead of `os.path`" item of #97.

The order of the files yielded is unchanged: the files directly within a directory come before those within its subdirectories, each in name order. A symbolic link to a directory is still not descended into, and a virtual environment is still skipped.

One behaviour changes. `os.walk` silently skips a directory it cannot read, which hid any missing requirement imported only by the files within it. The `pathlib` walk raises `PermissionError` instead, which both commands already report as a command line error. This is noted in the changelog and covered by a new test, which skips itself when the running user can read a mode 0 directory (Windows, or root).

The remaining `os` use in `common.py` is `os.path.normpath` in the file ignorer. There is no lexical equivalent in `pathlib` before Python 3.12, so it stays for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)