### PR TITLE
Add --use-gitignore to skip files which .gitignore ignores

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,9 @@ Release History
 
 3.1.0
 
+- Both commands gain a ``--use-gitignore`` option. Files and directories which
+  a ``.gitignore`` file ignores are then skipped, as they are by Git. Each
+  ``.gitignore`` file from the repository root down applies.
 - ``pip-missing-reqs`` gains a ``--transitive`` option. It also reports the
   dependencies of the distributions the source imports, followed recursively,
   which no requirements file lists. This checks a constraints file which must

--- a/README.rst
+++ b/README.rst
@@ -115,6 +115,16 @@ A virtual environment within the checked directory is skipped automatically.
 A directory is treated as a virtual environment when it contains a
 ``pyvenv.cfg`` file, which ``venv``, ``virtualenv`` and ``uv`` all create.
 
+Files which Git ignores can be skipped too, with `--use-gitignore` (shorthand
+is `-g`)::
+
+    pip-missing-reqs --use-gitignore sample
+    pip-extra-reqs --use-gitignore sample
+
+Each ``.gitignore`` file from the repository root down to the checked
+directory applies, as it does in Git. A file or directory which one ignores
+is not scanned. A file given directly on the command line is always scanned.
+
 
 Excluding modules from the check
 --------------------------------

--- a/pip_check_reqs/common.py
+++ b/pip_check_reqs/common.py
@@ -426,7 +426,7 @@ def _scan_directory(
 def pyfiles(
     root: Path,
     *,
-    use_gitignore: bool = False,
+    use_gitignore: bool,
 ) -> Generator[Path, None, None]:
     """Yield each Python source file within ``root``.
 
@@ -520,7 +520,7 @@ def log_level(*, debug: bool, verbose: bool) -> int:
 def source_module_names(
     *,
     paths: Iterable[Path],
-    use_gitignore: bool = False,
+    use_gitignore: bool,
 ) -> set[str]:
     """Return the top-level module names which the scanned source provides.
 
@@ -546,7 +546,7 @@ def find_imported_modules(
     paths: Iterable[Path],
     ignore_files_function: Callable[[Path], bool],
     ignore_modules_function: Callable[[str], bool],
-    use_gitignore: bool = False,
+    use_gitignore: bool,
 ) -> ImportedModules:
     # We take the names the source provides before scanning, as an ignored
     # file still gives a module which the source, and not an installed

--- a/pip_check_reqs/common.py
+++ b/pip_check_reqs/common.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING
 
 from packaging.requirements import Requirement
 from packaging.utils import NormalizedName, canonicalize_name
+from pathspec import GitIgnoreSpec
 from pip._internal.commands.show import (
     _PackageInfo,  # pyright: ignore[reportPrivateUsage]
     search_packages_info,
@@ -33,7 +34,13 @@ from . import __version__
 
 if TYPE_CHECKING:
     import argparse
-    from collections.abc import Callable, Generator, Iterable, Iterator
+    from collections.abc import (
+        Callable,
+        Generator,
+        Iterable,
+        Iterator,
+        Sequence,
+    )
     from typing import Any, NoReturn, TextIO
 
     from pip._internal.models.link import Link
@@ -305,12 +312,132 @@ def _is_virtual_environment(*, directory: Path) -> bool:
     return (directory / "pyvenv.cfg").is_file()
 
 
-def pyfiles(root: Path) -> Generator[Path, None, None]:
+@dataclass(frozen=True)
+class _GitIgnore:
+    """The patterns of one ``.gitignore`` file."""
+
+    directory: Path
+    """The directory holding the file, which its patterns are relative to."""
+
+    spec: GitIgnoreSpec
+
+
+def _read_gitignore(*, directory: Path) -> _GitIgnore | None:
+    """Return the ``.gitignore`` file in ``directory``, if there is one."""
+    gitignore_file = directory / ".gitignore"
+    if not gitignore_file.is_file():
+        return None
+    with gitignore_file.open(encoding="utf-8") as gitignore_lines:
+        spec = GitIgnoreSpec.from_lines(gitignore_lines)
+    return _GitIgnore(directory=directory, spec=spec)
+
+
+def _ancestor_gitignores(*, root: Path) -> list[_GitIgnore]:
+    """Return the ``.gitignore`` files above ``root`` within its repository.
+
+    The source to scan is often a directory within the repository, such as
+    ``src``, while the ``.gitignore`` file is at the repository root. Git
+    applies that file to every directory below it, so we do too. A
+    ``.gitignore`` file above the repository, or anywhere when ``root`` is
+    not within a repository, has no effect in Git, so we read no further
+    than the directory holding ``.git``.
+
+    The files are given from the repository root down, as a pattern in a
+    deeper file takes precedence over one in a shallower file.
+    """
+    repository_directories: list[Path] = []
+    for directory in root.parents:
+        repository_directories.append(directory)
+        if (directory / ".git").exists():
+            break
+    else:
+        return []
+
+    gitignores: list[_GitIgnore] = []
+    for directory in reversed(repository_directories):
+        gitignore = _read_gitignore(directory=directory)
+        if gitignore is not None:
+            gitignores.append(gitignore)
+    return gitignores
+
+
+def _is_gitignored(
+    *,
+    path: Path,
+    is_directory: bool,
+    gitignores: Sequence[_GitIgnore],
+) -> bool:
+    """Return whether the ``.gitignore`` files which apply ignore ``path``.
+
+    ``gitignores`` holds the files which apply to ``path``, from the
+    shallowest to the deepest. The last pattern to match decides, so a
+    deeper file overrides a shallower one, as it does in Git.
+    """
+    ignored = False
+    for gitignore in gitignores:
+        relative_path = path.relative_to(gitignore.directory).as_posix()
+        # A pattern with a trailing slash matches only a directory, and a
+        # directory is told apart by a trailing slash on the path.
+        if is_directory:
+            relative_path += "/"
+        result = gitignore.spec.check_file(relative_path)
+        if result.include is not None:
+            ignored = result.include
+    if ignored:
+        log.debug("skipping ignored by .gitignore: %s", path)
+    return ignored
+
+
+def _directory_gitignores(
+    *,
+    directory: Path,
+    parent_gitignores: Sequence[_GitIgnore],
+) -> list[_GitIgnore]:
+    """Return the ``.gitignore`` files which apply within ``directory``.
+
+    Those are the files which apply within the parent directory, plus the
+    file in ``directory`` itself, if there is one.
+    """
+    gitignores = list(parent_gitignores)
+    gitignore = _read_gitignore(directory=directory)
+    if gitignore is not None:
+        gitignores.append(gitignore)
+    return gitignores
+
+
+def _scan_directory(
+    *,
+    directory: Path,
+    gitignores: Sequence[_GitIgnore],
+) -> bool:
+    """Return whether to look for Python files within ``directory``."""
+    if _is_virtual_environment(directory=directory):
+        log.debug("skipping virtual environment: %s", directory)
+        return False
+    # Git does not look within an ignored directory, so no pattern can
+    # bring back anything in it, and we need not descend into it.
+    return not _is_gitignored(
+        path=directory,
+        is_directory=True,
+        gitignores=gitignores,
+    )
+
+
+def pyfiles(
+    root: Path,
+    *,
+    use_gitignore: bool = False,
+) -> Generator[Path, None, None]:
     """Yield each Python source file within ``root``.
 
     A virtual environment within ``root`` is skipped. Its files belong to
     the installed distributions rather than to the project, and scanning
     them reports every import the environment makes as a use.
+
+    With ``use_gitignore``, a file or directory which a ``.gitignore`` file
+    ignores is skipped as well. A ``.gitignore`` file in any directory of
+    the repository applies, from the repository root down to the directory
+    of the file. A file given directly as ``root`` is always scanned.
     """
     if not root.exists():
         msg = f"source path not found: {root}"
@@ -328,22 +455,40 @@ def pyfiles(root: Path) -> Generator[Path, None, None]:
             raise ValueError(msg)
         return
 
+    # The ``.gitignore`` files which apply within each directory we walk.
+    # ``os.walk`` visits a directory before the directories within it, so
+    # the files which apply to a directory are those of its parent plus its
+    # own.
+    gitignores_by_directory: dict[Path, list[_GitIgnore]] = {}
+    if use_gitignore:
+        gitignores_by_directory[root.parent] = _ancestor_gitignores(root=root)
+
     for dirpath, dirnames, filenames in os.walk(root):
         directory = Path(dirpath)
-        kept_dirnames: list[str] = []
-        for dirname in sorted(dirnames):
-            if _is_virtual_environment(directory=directory / dirname):
-                log.debug(
-                    "skipping virtual environment: %s",
-                    directory / dirname,
-                )
-                continue
-            kept_dirnames.append(dirname)
+        gitignores: list[_GitIgnore] = []
+        if use_gitignore:
+            gitignores = _directory_gitignores(
+                directory=directory,
+                parent_gitignores=gitignores_by_directory[directory.parent],
+            )
+            gitignores_by_directory[directory] = gitignores
+
         # Assigning in place prunes the directories ``os.walk`` descends
         # into.
-        dirnames[:] = kept_dirnames
+        dirnames[:] = [
+            dirname
+            for dirname in sorted(dirnames)
+            if _scan_directory(
+                directory=directory / dirname,
+                gitignores=gitignores,
+            )
+        ]
         for filename in sorted(filenames):
-            if filename.endswith(".py"):
+            if filename.endswith(".py") and not _is_gitignored(
+                path=directory / filename,
+                is_directory=False,
+                gitignores=gitignores,
+            ):
                 yield directory / filename
 
 
@@ -372,7 +517,11 @@ def log_level(*, debug: bool, verbose: bool) -> int:
     return logging.WARNING
 
 
-def source_module_names(*, paths: Iterable[Path]) -> set[str]:
+def source_module_names(
+    *,
+    paths: Iterable[Path],
+    use_gitignore: bool = False,
+) -> set[str]:
     """Return the top-level module names which the scanned source provides.
 
     A module of the source we scan is not expected to be installed, so we
@@ -383,7 +532,7 @@ def source_module_names(*, paths: Iterable[Path]) -> set[str]:
     names: set[str] = set()
     for path in paths:
         absolute_path = path.absolute()
-        for filename in pyfiles(path):
+        for filename in pyfiles(path, use_gitignore=use_gitignore):
             names.add(filename.stem)
             if absolute_path.is_dir():
                 relative_filename = filename.relative_to(absolute_path)
@@ -397,14 +546,18 @@ def find_imported_modules(
     paths: Iterable[Path],
     ignore_files_function: Callable[[Path], bool],
     ignore_modules_function: Callable[[str], bool],
+    use_gitignore: bool = False,
 ) -> ImportedModules:
     # We take the names the source provides before scanning, as an ignored
     # file still gives a module which the source, and not an installed
     # distribution, provides.
-    provided_names = source_module_names(paths=paths)
+    provided_names = source_module_names(
+        paths=paths,
+        use_gitignore=use_gitignore,
+    )
     vis = _ImportVisitor(ignore_modules_function=ignore_modules_function)
     for path in paths:
-        for filename in pyfiles(path):
+        for filename in pyfiles(path, use_gitignore=use_gitignore):
             if ignore_files_function(filename):
                 log.info("ignoring: %s", filename)
                 continue

--- a/pip_check_reqs/find_extra_reqs.py
+++ b/pip_check_reqs/find_extra_reqs.py
@@ -24,7 +24,7 @@ def find_extra_reqs(
     ignore_modules_function: Callable[[str], bool],
     ignore_requirements_function: Callable[[str], bool],
     skip_incompatible: bool,
-    use_gitignore: bool = False,
+    use_gitignore: bool,
 ) -> list[str]:
     # 1. find files used by imports in the code (as best we can without
     #    executing)

--- a/pip_check_reqs/find_extra_reqs.py
+++ b/pip_check_reqs/find_extra_reqs.py
@@ -24,6 +24,7 @@ def find_extra_reqs(
     ignore_modules_function: Callable[[str], bool],
     ignore_requirements_function: Callable[[str], bool],
     skip_incompatible: bool,
+    use_gitignore: bool = False,
 ) -> list[str]:
     # 1. find files used by imports in the code (as best we can without
     #    executing)
@@ -31,6 +32,7 @@ def find_extra_reqs(
         paths=paths,
         ignore_files_function=ignore_files_function,
         ignore_modules_function=ignore_modules_function,
+        use_gitignore=use_gitignore,
     ).found
 
     installed_names = common.installed_distribution_names()
@@ -104,6 +106,14 @@ def main(arguments: list[str] | None = None) -> None:
         help="reqs in requirements to ignore",
     )
     parser.add_argument(
+        "-g",
+        "--use-gitignore",
+        dest="use_gitignore",
+        action="store_true",
+        default=False,
+        help="skip files and directories which a .gitignore file ignores",
+    )
+    parser.add_argument(
         "-s",
         "--skip-incompatible",
         dest="skip_incompatible",
@@ -173,6 +183,7 @@ def main(arguments: list[str] | None = None) -> None:
             ignore_modules_function=ignore_mods,
             ignore_requirements_function=ignore_reqs,
             skip_incompatible=parse_result.skip_incompatible,
+            use_gitignore=parse_result.use_gitignore,
         )
     except (OSError, ValueError) as error:
         common.report_input_error(

--- a/pip_check_reqs/find_missing_reqs.py
+++ b/pip_check_reqs/find_missing_reqs.py
@@ -44,7 +44,7 @@ def find_missing_reqs(
     additional_requirements_filenames: Iterable[Path] = (),
     *,
     transitive: bool = False,
-    use_gitignore: bool = False,
+    use_gitignore: bool,
 ) -> MissingRequirements:
     # 1. find files used by imports in the code (as best we can without
     #    executing)

--- a/pip_check_reqs/find_missing_reqs.py
+++ b/pip_check_reqs/find_missing_reqs.py
@@ -44,6 +44,7 @@ def find_missing_reqs(
     additional_requirements_filenames: Iterable[Path] = (),
     *,
     transitive: bool = False,
+    use_gitignore: bool = False,
 ) -> MissingRequirements:
     # 1. find files used by imports in the code (as best we can without
     #    executing)
@@ -51,6 +52,7 @@ def find_missing_reqs(
         paths=paths,
         ignore_files_function=ignore_files_function,
         ignore_modules_function=ignore_modules_function,
+        use_gitignore=use_gitignore,
     )
     used_modules = imported_modules.found
 
@@ -172,6 +174,14 @@ def main(arguments: list[str] | None = None) -> None:
         help="used module names (globs are ok) to ignore",
     )
     parser.add_argument(
+        "-g",
+        "--use-gitignore",
+        dest="use_gitignore",
+        action="store_true",
+        default=False,
+        help="skip files and directories which a .gitignore file ignores",
+    )
+    parser.add_argument(
         "-t",
         "--transitive",
         dest="transitive",
@@ -245,6 +255,7 @@ def main(arguments: list[str] | None = None) -> None:
             ignore_modules_function=ignore_mods,
             additional_requirements_filenames=requirements_filenames[1:],
             transitive=parse_result.transitive,
+            use_gitignore=parse_result.use_gitignore,
         )
     except (OSError, ValueError) as error:
         common.report_input_error(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 packaging >= 26.3
+pathspec >= 0.12.1
 pip >= 26.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 packaging >= 26.3
-pathspec >= 0.12.1
+pathspec >= 1.0.3
 pip >= 26.2.1

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -160,6 +160,139 @@ def test_pyfiles_root_is_virtual_environment(tmp_path: Path) -> None:
     assert list(common.pyfiles(root=venv)) == [venv_python_file]
 
 
+def test_pyfiles_use_gitignore(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """With ``use_gitignore``, what a ``.gitignore`` file ignores is skipped.
+
+    A pattern applies from the directory of its ``.gitignore`` file down,
+    a later pattern overrides an earlier one, and a ``.gitignore`` file in
+    a deeper directory overrides one above it. An ignored directory is not
+    looked within, so a deeper file cannot bring back anything in it.
+    Without ``use_gitignore``, a ``.gitignore`` file has no effect.
+    """
+    (tmp_path / ".gitignore").write_text(
+        textwrap.dedent(
+            """\
+            build/
+            generated_*.py
+            !generated_keep.py
+            """,
+        ),
+        encoding="utf-8",
+    )
+    kept = tmp_path / "kept.py"
+    kept.touch()
+    generated = tmp_path / "generated_spam.py"
+    generated.touch()
+    generated_keep = tmp_path / "generated_keep.py"
+    generated_keep.touch()
+
+    build = tmp_path / "build"
+    build.mkdir()
+    built = build / "built.py"
+    built.touch()
+    # Git ignores everything within an ignored directory, so a deeper file
+    # cannot bring anything in it back.
+    (build / ".gitignore").write_text("!built.py\n", encoding="utf-8")
+
+    # A pattern ending in a slash matches only a directory, so a file of
+    # the same name is kept.
+    build_file = tmp_path / "subdir" / "build"
+    build_file.parent.mkdir()
+    build_file.touch()
+    nested_generated = tmp_path / "subdir" / "generated_eggs.py"
+    nested_generated.touch()
+    # A deeper file overrides a shallower one.
+    (tmp_path / "subdir" / ".gitignore").write_text(
+        "!generated_eggs.py\n",
+        encoding="utf-8",
+    )
+
+    assert list(common.pyfiles(root=tmp_path)) == [
+        generated_keep,
+        generated,
+        kept,
+        built,
+        nested_generated,
+    ]
+
+    with caplog.at_level(level=logging.DEBUG):
+        found = list(common.pyfiles(root=tmp_path, use_gitignore=True))
+
+    assert found == [generated_keep, kept, nested_generated]
+    assert f"skipping ignored by .gitignore: {build}" in caplog.text
+    assert f"skipping ignored by .gitignore: {generated}" in caplog.text
+
+
+def test_pyfiles_use_gitignore_above_root(tmp_path: Path) -> None:
+    """A ``.gitignore`` file above the scanned directory applies.
+
+    The source to scan is often a directory within the repository, such as
+    a package under ``src``, while the ``.gitignore`` file is at the
+    repository root. A pattern anchored to the repository root is matched
+    from there, and a directory in between need not have a ``.gitignore``
+    file of its own. A ``.gitignore`` file above the repository has no
+    effect.
+    """
+    (tmp_path / ".gitignore").write_text("outside.py\n", encoding="utf-8")
+    repository = tmp_path / "repository"
+    (repository / ".git").mkdir(parents=True)
+    (repository / ".gitignore").write_text(
+        textwrap.dedent(
+            """\
+            /src/anchored.py
+            unanchored.py
+            """,
+        ),
+        encoding="utf-8",
+    )
+    source = repository / "src" / "package"
+    source.mkdir(parents=True)
+    outside = source / "outside.py"
+    outside.touch()
+    # The anchored pattern names a file directly under ``src``, not one in
+    # a directory below it.
+    anchored = source / "anchored.py"
+    anchored.touch()
+    (source / "unanchored.py").touch()
+
+    assert list(common.pyfiles(root=source, use_gitignore=True)) == [
+        anchored,
+        outside,
+    ]
+
+
+def test_pyfiles_use_gitignore_outside_repository(tmp_path: Path) -> None:
+    """Outside a repository, only ``.gitignore`` files within the root apply.
+
+    Git reads no ``.gitignore`` file outside a repository, so one above the
+    scanned directory has no effect when no ``.git`` is found above it.
+    """
+    (tmp_path / ".gitignore").write_text("above.py\n", encoding="utf-8")
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / ".gitignore").write_text("within.py\n", encoding="utf-8")
+    above = source / "above.py"
+    above.touch()
+    (source / "within.py").touch()
+
+    assert list(common.pyfiles(root=source, use_gitignore=True)) == [above]
+
+
+def test_pyfiles_use_gitignore_root_file(tmp_path: Path) -> None:
+    """A file given directly as the source path is scanned even if ignored.
+
+    The user has named the file, so it is what they want checked.
+    """
+    (tmp_path / ".gitignore").write_text("ignored.py\n", encoding="utf-8")
+    ignored = tmp_path / "ignored.py"
+    ignored.touch()
+
+    assert list(common.pyfiles(root=ignored, use_gitignore=True)) == [ignored]
+
+
 @pytest.mark.parametrize(
     argnames=("statement", "expected_module_names"),
     argvalues=[

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -62,7 +62,9 @@ def test_found_module() -> None:
 def test_pyfiles_file(tmp_path: Path) -> None:
     python_file = tmp_path / "example.py"
     python_file.touch()
-    assert list(common.pyfiles(root=python_file)) == [python_file]
+    assert list(common.pyfiles(root=python_file, use_gitignore=False)) == [
+        python_file,
+    ]
 
 
 def test_pyfiles_file_no_dice(tmp_path: Path) -> None:
@@ -75,7 +77,7 @@ def test_pyfiles_file_no_dice(tmp_path: Path) -> None:
             f"{not_python_file} is not a python file or directory",
         ),
     ):
-        list(common.pyfiles(root=not_python_file))
+        list(common.pyfiles(root=not_python_file, use_gitignore=False))
 
 
 def test_pyfiles_package(tmp_path: Path) -> None:
@@ -89,7 +91,7 @@ def test_pyfiles_package(tmp_path: Path) -> None:
 
     not_python_file.touch()
 
-    assert list(common.pyfiles(root=tmp_path)) == [
+    assert list(common.pyfiles(root=tmp_path, use_gitignore=False)) == [
         python_file,
         nested_python_file,
     ]
@@ -122,7 +124,7 @@ def test_pyfiles_skips_virtual_environment(
     lookalike_python_file.touch()
 
     with caplog.at_level(level=logging.DEBUG):
-        found = list(common.pyfiles(root=tmp_path))
+        found = list(common.pyfiles(root=tmp_path, use_gitignore=False))
 
     assert found == [python_file, lookalike_python_file]
     assert f"skipping virtual environment: {venv}" in caplog.text
@@ -140,7 +142,7 @@ def test_pyfiles_does_not_follow_directory_symlink(tmp_path: Path) -> None:
     (linked_directory / "spam.py").touch()
     (linked_directory / "loop").symlink_to(target=tmp_path)
 
-    assert list(common.pyfiles(root=tmp_path)) == [
+    assert list(common.pyfiles(root=tmp_path, use_gitignore=False)) == [
         python_file,
         linked_directory / "spam.py",
     ]
@@ -157,7 +159,9 @@ def test_pyfiles_root_is_virtual_environment(tmp_path: Path) -> None:
     venv_python_file = venv / "spam.py"
     venv_python_file.touch()
 
-    assert list(common.pyfiles(root=venv)) == [venv_python_file]
+    assert list(common.pyfiles(root=venv, use_gitignore=False)) == [
+        venv_python_file,
+    ]
 
 
 def test_pyfiles_use_gitignore(
@@ -210,7 +214,7 @@ def test_pyfiles_use_gitignore(
         encoding="utf-8",
     )
 
-    assert list(common.pyfiles(root=tmp_path)) == [
+    assert list(common.pyfiles(root=tmp_path, use_gitignore=False)) == [
         generated_keep,
         generated,
         kept,
@@ -330,6 +334,7 @@ def test_find_imported_modules_simple(
         paths=[tmp_path],
         ignore_files_function=common.file_ignorer(ignore_cfg=[]),
         ignore_modules_function=common.ignorer(ignore_cfg=[]),
+        use_gitignore=False,
     ).found
 
     assert set(result.keys()) == expected_module_names
@@ -369,6 +374,7 @@ def test_find_imported_modules_frozen(
         paths=[tmp_path],
         ignore_files_function=common.file_ignorer(ignore_cfg=[]),
         ignore_modules_function=common.ignorer(ignore_cfg=[]),
+        use_gitignore=False,
     ).found
 
     assert set(result.keys()) == set()
@@ -389,6 +395,7 @@ def test_find_imported_modules_built_in(
         paths=[tmp_path],
         ignore_files_function=common.file_ignorer(ignore_cfg=[]),
         ignore_modules_function=common.ignorer(ignore_cfg=[]),
+        use_gitignore=False,
     ).found
 
     assert set(result.keys()) == set()
@@ -419,6 +426,7 @@ def test_find_imported_modules_main(
         paths=[tmp_path],
         ignore_files_function=common.file_ignorer(ignore_cfg=[]),
         ignore_modules_function=common.ignorer(ignore_cfg=[]),
+        use_gitignore=False,
     ).found
 
     assert set(result.keys()) == set()
@@ -447,6 +455,7 @@ def test_find_imported_modules_no_spec(tmp_path: Path) -> None:
             paths=[tmp_path],
             ignore_files_function=common.file_ignorer(ignore_cfg=[]),
             ignore_modules_function=common.ignorer(ignore_cfg=[]),
+            use_gitignore=False,
         ).found
     finally:
         del sys.modules[name]
@@ -475,6 +484,7 @@ def test_find_imported_modules_syntax_error(tmp_path: Path) -> None:
             paths=[tmp_path],
             ignore_files_function=common.file_ignorer(ignore_cfg=[]),
             ignore_modules_function=common.ignorer(ignore_cfg=[]),
+            use_gitignore=False,
         )
 
 
@@ -494,6 +504,7 @@ def test_find_imported_modules_period(tmp_path: Path) -> None:
         paths=[tmp_path],
         ignore_files_function=common.file_ignorer(ignore_cfg=[]),
         ignore_modules_function=common.ignorer(ignore_cfg=[]),
+        use_gitignore=False,
     ).found
 
     assert set(result.keys()) == {"ruamel.yaml"}
@@ -521,6 +532,7 @@ def test_find_imported_modules_missing_from_submodule(
         paths=[source_dir],
         ignore_files_function=common.file_ignorer(ignore_cfg=[]),
         ignore_modules_function=common.ignorer(ignore_cfg=[]),
+        use_gitignore=False,
     ).found
 
     assert not result
@@ -590,6 +602,7 @@ def test_find_imported_modules_advanced(
         paths=[root],
         ignore_files_function=ignore_files,
         ignore_modules_function=ignore_mods,
+        use_gitignore=False,
     ).found
     assert set(result) == set(expect)
     absolute_locations = result["ast"].locations
@@ -623,6 +636,7 @@ def test_find_imported_modules_uninstalled(tmp_path: Path) -> None:
         paths=[source_dir],
         ignore_files_function=common.file_ignorer(ignore_cfg=[]),
         ignore_modules_function=common.ignorer(ignore_cfg=[]),
+        use_gitignore=False,
     )
 
     assert set(result.found) == {"re"}
@@ -664,6 +678,7 @@ def test_find_imported_modules_uninstalled_ignored(
         ignore_modules_function=common.ignorer(
             ignore_cfg=[ignore_glob.format(name=name)],
         ),
+        use_gitignore=False,
     )
 
     assert not result.uninstalled
@@ -688,6 +703,7 @@ def test_find_imported_modules_uninstalled_no_spec(tmp_path: Path) -> None:
             paths=[source_dir],
             ignore_files_function=common.file_ignorer(ignore_cfg=[]),
             ignore_modules_function=common.ignorer(ignore_cfg=[]),
+            use_gitignore=False,
         )
     finally:
         del sys.modules[name]
@@ -716,6 +732,7 @@ def test_find_imported_modules_uninstalled_submodule(tmp_path: Path) -> None:
         paths=[source_dir],
         ignore_files_function=common.file_ignorer(ignore_cfg=[]),
         ignore_modules_function=common.ignorer(ignore_cfg=[]),
+        use_gitignore=False,
     )
 
     assert not result.uninstalled
@@ -768,6 +785,7 @@ def test_find_imported_modules_uninstalled_optional(
         paths=[source_dir],
         ignore_files_function=common.file_ignorer(ignore_cfg=[]),
         ignore_modules_function=common.ignorer(ignore_cfg=[]),
+        use_gitignore=False,
     )
 
     assert not result.uninstalled
@@ -846,6 +864,7 @@ def test_find_imported_modules_uninstalled_not_optional(
         paths=[source_dir],
         ignore_files_function=common.file_ignorer(ignore_cfg=[]),
         ignore_modules_function=common.ignorer(ignore_cfg=[]),
+        use_gitignore=False,
     )
 
     assert set(result.uninstalled) == {name}
@@ -874,6 +893,7 @@ def test_find_imported_modules_optional_installed(tmp_path: Path) -> None:
         paths=[source_dir],
         ignore_files_function=common.file_ignorer(ignore_cfg=[]),
         ignore_modules_function=common.ignorer(ignore_cfg=[]),
+        use_gitignore=False,
     )
 
     assert set(result.found) == {"pytest"}
@@ -914,6 +934,7 @@ def test_find_imported_modules_source_module(
             ignore_cfg=["*ignored.py"],
         ),
         ignore_modules_function=common.ignorer(ignore_cfg=[]),
+        use_gitignore=False,
     )
 
     assert not result.uninstalled
@@ -924,7 +945,10 @@ def test_source_module_names_file(tmp_path: Path) -> None:
     source_file = tmp_path / "spam.py"
     source_file.touch()
 
-    result = common.source_module_names(paths=[source_file])
+    result = common.source_module_names(
+        paths=[source_file],
+        use_gitignore=False,
+    )
 
     assert result == {"spam"}
 
@@ -1366,6 +1390,7 @@ def test_used_packages_other_case_path(  # pragma: no cover
             paths=[source_file],
             ignore_files_function=common.file_ignorer(ignore_cfg=[]),
             ignore_modules_function=common.ignorer(ignore_cfg=[]),
+            use_gitignore=False,
         )
         used = common.used_packages(
             used_modules=imported.found,

--- a/tests/test_find_extra_reqs.py
+++ b/tests/test_find_extra_reqs.py
@@ -210,6 +210,59 @@ def test_main_ignore_requirement_glob(
     assert not caplog.records
 
 
+def test_main_use_gitignore(
+    *,
+    caplog: pytest.LogCaptureFixture,
+    tmp_path: Path,
+) -> None:
+    """With ``--use-gitignore``, a file a ``.gitignore`` ignores is skipped.
+
+    A requirement which only an ignored file imports is then reported as
+    extra.
+    """
+    # We need to import something which is installed.
+    # We choose `pytest` because we know it is installed.
+    imported_package = pytest
+
+    requirements_file = tmp_path / "requirements.txt"
+    requirements_file.write_text(f"{imported_package.__name__}\n")
+
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    (source_dir / ".gitignore").write_text("ignored.py\n", encoding="utf-8")
+    (source_dir / "ignored.py").write_text(
+        f"import {imported_package.__name__}",
+    )
+
+    caplog.set_level(logging.WARNING)
+
+    find_extra_reqs.main(
+        arguments=[
+            "--requirements",
+            str(requirements_file),
+            str(source_dir),
+        ],
+    )
+
+    assert caplog.records == []
+
+    with pytest.raises(SystemExit) as excinfo:
+        find_extra_reqs.main(
+            arguments=[
+                "--requirements",
+                str(requirements_file),
+                "--use-gitignore",
+                str(source_dir),
+            ],
+        )
+
+    assert excinfo.value.code == 1
+    assert [record.message for record in caplog.records] == [
+        "Extra requirements:",
+        f"{imported_package.__name__} in {requirements_file}",
+    ]
+
+
 def test_main_no_spec(capsys: pytest.CaptureFixture[str]) -> None:
     with pytest.raises(SystemExit) as excinfo:
         find_extra_reqs.main(arguments=[])

--- a/tests/test_find_extra_reqs.py
+++ b/tests/test_find_extra_reqs.py
@@ -54,6 +54,7 @@ def test_find_extra_reqs(tmp_path: Path) -> None:
         ignore_modules_function=common.ignorer(ignore_cfg=[]),
         ignore_requirements_function=common.ignorer(ignore_cfg=[]),
         skip_incompatible=False,
+        use_gitignore=False,
     )
     expected_result = [installed_not_imported_required_package.__name__]
     assert result == expected_result
@@ -88,6 +89,7 @@ def test_uninstalled_requirement_is_not_extra(
         ignore_modules_function=common.ignorer(ignore_cfg=[]),
         ignore_requirements_function=common.ignorer(ignore_cfg=[]),
         skip_incompatible=False,
+        use_gitignore=False,
     )
 
     assert not result
@@ -506,6 +508,7 @@ def test_editable_requirement_is_not_extra(
         ignore_modules_function=common.ignorer(ignore_cfg=[]),
         ignore_requirements_function=common.ignorer(ignore_cfg=[]),
         skip_incompatible=False,
+        use_gitignore=False,
     )
 
     assert not result
@@ -534,6 +537,7 @@ def test_editable_requirement_not_imported_is_extra(
         ignore_modules_function=common.ignorer(ignore_cfg=[]),
         ignore_requirements_function=common.ignorer(ignore_cfg=[]),
         skip_incompatible=False,
+        use_gitignore=False,
     )
 
     assert result == [editable_install.distribution_name]
@@ -568,6 +572,7 @@ def test_requirement_installed_within_working_directory_is_not_extra(
         ignore_modules_function=common.ignorer(ignore_cfg=[]),
         ignore_requirements_function=common.ignorer(ignore_cfg=[]),
         skip_incompatible=False,
+        use_gitignore=False,
     )
 
     assert not result

--- a/tests/test_find_missing_reqs.py
+++ b/tests/test_find_missing_reqs.py
@@ -52,6 +52,7 @@ def test_find_missing_reqs(tmp_path: Path) -> None:
         paths=[source_dir],
         ignore_files_function=common.file_ignorer(ignore_cfg=[]),
         ignore_modules_function=common.ignorer(ignore_cfg=[]),
+        use_gitignore=False,
     )
     expected_result = [
         (
@@ -97,6 +98,7 @@ def test_uninstalled_import_is_reported(
         paths=[source_dir],
         ignore_files_function=common.file_ignorer(ignore_cfg=[]),
         ignore_modules_function=common.ignorer(ignore_cfg=[]),
+        use_gitignore=False,
     )
 
     assert not result.used
@@ -130,6 +132,7 @@ def test_uninstalled_import_of_requirement_is_not_reported(
         paths=[source_dir],
         ignore_files_function=common.file_ignorer(ignore_cfg=[]),
         ignore_modules_function=common.ignorer(ignore_cfg=[]),
+        use_gitignore=False,
     )
 
     assert not result.used
@@ -641,6 +644,7 @@ def test_editable_requirement_is_missing(
         paths=[source_dir],
         ignore_files_function=common.file_ignorer(ignore_cfg=[]),
         ignore_modules_function=common.ignorer(ignore_cfg=[]),
+        use_gitignore=False,
     )
 
     (name, uses) = next(iter(result.used))
@@ -675,6 +679,7 @@ def test_own_source_installed_as_editable_is_not_missing(
         paths=[editable_install.source_directory],
         ignore_files_function=common.file_ignorer(ignore_cfg=[]),
         ignore_modules_function=common.ignorer(ignore_cfg=[]),
+        use_gitignore=False,
     )
 
     assert not result.used
@@ -708,6 +713,7 @@ def test_transitive_dependencies_are_reported(
         ignore_files_function=common.file_ignorer(ignore_cfg=[]),
         ignore_modules_function=common.ignorer(ignore_cfg=[]),
         transitive=True,
+        use_gitignore=False,
     )
 
     assert not result.used
@@ -738,6 +744,7 @@ def test_transitive_dependencies_are_not_checked_by_default(
         paths=[source_dir],
         ignore_files_function=common.file_ignorer(ignore_cfg=[]),
         ignore_modules_function=common.ignorer(ignore_cfg=[]),
+        use_gitignore=False,
     )
 
     assert not result.used
@@ -774,6 +781,7 @@ def test_listed_transitive_dependencies_are_not_reported(
         ignore_files_function=common.file_ignorer(ignore_cfg=[]),
         ignore_modules_function=common.ignorer(ignore_cfg=[]),
         transitive=True,
+        use_gitignore=False,
     )
 
     assert not result.used
@@ -806,6 +814,7 @@ def test_used_distribution_is_not_reported_as_transitive(
         ignore_files_function=common.file_ignorer(ignore_cfg=[]),
         ignore_modules_function=common.ignorer(ignore_cfg=[]),
         transitive=True,
+        use_gitignore=False,
     )
 
     assert [name for name, _ in result.used] == [dependency_chain.top]
@@ -882,6 +891,7 @@ def test_import_installed_within_working_directory_is_missing(
         paths=[source_dir],
         ignore_files_function=common.file_ignorer(ignore_cfg=[]),
         ignore_modules_function=common.ignorer(ignore_cfg=[]),
+        use_gitignore=False,
     )
 
     (name, uses) = next(iter(result.used))

--- a/tests/test_find_missing_reqs.py
+++ b/tests/test_find_missing_reqs.py
@@ -262,6 +262,64 @@ def test_main_failure(
     )
 
 
+def test_main_use_gitignore(
+    *,
+    caplog: pytest.LogCaptureFixture,
+    tmp_path: Path,
+) -> None:
+    """With ``--use-gitignore``, a file a ``.gitignore`` ignores is skipped.
+
+    A module which only an ignored file provides is then not known to be
+    provided by the source, so an import of it is reported as uninstalled.
+    """
+    requirements_file = tmp_path / "requirements.txt"
+    requirements_file.touch()
+
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    (source_dir / ".gitignore").write_text("ignored.py\n", encoding="utf-8")
+    # We need to import something which is installed.
+    # We choose `pytest` because we know it is installed.
+    ignored_file = source_dir / "ignored.py"
+    ignored_file.write_text("import pytest")
+    source_file = source_dir / "source.py"
+    source_file.write_text("import ignored")
+
+    caplog.set_level(logging.WARNING)
+
+    with pytest.raises(SystemExit) as excinfo:
+        find_missing_reqs.main(
+            arguments=[
+                "--requirements",
+                str(requirements_file),
+                str(source_dir),
+            ],
+        )
+
+    assert excinfo.value.code == 1
+    assert [record.message for record in caplog.records] == [
+        "Missing requirements:",
+        f"{ignored_file}:1 dist=pytest module=pytest",
+    ]
+
+    caplog.clear()
+    find_missing_reqs.main(
+        arguments=[
+            "--requirements",
+            str(requirements_file),
+            "--use-gitignore",
+            str(source_dir),
+        ],
+    )
+
+    assert [record.message for record in caplog.records] == [
+        (
+            f"{source_file}:1 module=ignored is not installed, so we cannot "
+            "tell which requirement provides it"
+        ),
+    ]
+
+
 def test_main_no_spec(capsys: pytest.CaptureFixture[str]) -> None:
     with pytest.raises(SystemExit) as excinfo:
         find_missing_reqs.main(arguments=[])


### PR DESCRIPTION
Closes #53.

Both `pip-missing-reqs` and `pip-extra-reqs` gain a `--use-gitignore` option (short form `-g`) which skips files and directories that a `.gitignore` file ignores, as Git does. Every `.gitignore` from the repository root down to the scanned directory applies, a deeper file overrides a shallower one, an ignored directory is not descended into, and a file named directly on the command line is always scanned. Matching uses the `pathspec` library, which is added as a dependency. Tests cover nested and anchored patterns, negation, an ancestor without its own `.gitignore`, scanning outside a repository, and both CLIs, and the README and changelog document the option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
