### PR TITLE
Normalize an ignored file's path with pathlib rather than os.path.normpath

### DIFF
--- a/pip_check_reqs/common.py
+++ b/pip_check_reqs/common.py
@@ -813,6 +813,20 @@ def package_path(*, path: Path) -> Path | None:
     return path.parent
 
 
+def _normalized(*, path: Path) -> Path:
+    """Return an absolute path with each ``..`` component collapsed.
+
+    This is done on the path alone, without touching the file system, so a
+    symbolic link within the path is kept rather than followed. A ``..``
+    directly beneath the anchor is dropped, as there is nowhere above the
+    anchor to go.
+    """
+    normalized = Path(path.anchor)
+    for part in path.parts[len(normalized.parts) :]:
+        normalized = normalized.parent if part == ".." else normalized / part
+    return normalized
+
+
 def _null_ignorer(_: object) -> bool:
     return False
 
@@ -850,8 +864,8 @@ def file_ignorer(*, ignore_cfg: list[str]) -> Callable[[Path], bool]:
         # We use ``Path`` rather than ``os.path.relpath``, which raises
         # ``ValueError`` on Windows for a path on a different drive to the
         # working directory.
-        absolute_candidate = Path(
-            os.path.normpath(working_directory / candidate_path),
+        absolute_candidate = _normalized(
+            path=working_directory / candidate_path,
         )
         candidates = [str(candidate_path)]
         if absolute_candidate.is_relative_to(working_directory):

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -871,6 +871,26 @@ def test_file_ignorer(
     assert ignorer(candidate) == result
 
 
+def test_file_ignorer_symlink(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A file is matched by the path it was found under, not its target.
+
+    A symbolic link within the path is not followed, so a glob written for
+    the path as it appears in the project matches.
+    """
+    project = tmp_path / "project"
+    project.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (project / "link").symlink_to(target=outside)
+    monkeypatch.chdir(path=project)
+    ignorer = common.file_ignorer(ignore_cfg=["link/*"])
+
+    assert ignorer(Path.cwd() / "link" / "spam.py")
+
+
 @pytest.mark.skipif(
     condition=platform.system() != "Windows",
     reason="Only Windows has drives, which is what this test is about",


### PR DESCRIPTION
Part of #97 ("Use `pathlib.Path` instead of `os.path`").

Replace the `os.path.normpath` call in `file_ignorer` with a small pathlib helper which collapses each `..` component lexically. This removes the last `os.path` call in the package; `os` is still imported for `os.environ`.

`Path.resolve` was not used because it follows symbolic links, which would stop an ignore glob such as `link/*` matching a file by the path it was found under. A new test covers this.

No user-facing behaviour changes, so no changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)