### PR TITLE
Read pyproject.toml dependencies into RequirementSpec records

### DIFF
--- a/pip_check_reqs/common.py
+++ b/pip_check_reqs/common.py
@@ -28,6 +28,7 @@ from pip._internal.exceptions import InstallationError
 from pip._internal.network.session import PipSession
 from pip._internal.req.constructors import install_req_from_line
 from pip._internal.req.req_file import parse_requirements
+from pip._internal.utils.compat import tomllib
 from pip._internal.utils.urls import url_to_path
 from pip._internal.vcs.versioncontrol import vcs
 
@@ -925,9 +926,9 @@ def transitive_dependencies(
 class RequirementSpec:
     """One requirement a project declares.
 
-    A requirement comes from a line of a requirements file today. Keeping it
-    as a plain record lets another source, such as ``pyproject.toml``, give
-    requirements in the same form later.
+    A requirement comes from a line of a requirements file, or from the
+    ``dependencies`` list of a ``pyproject.toml`` file. Keeping it as a plain
+    record lets each source give requirements in the same form.
     """
 
     #: The distribution the requirement asks for.
@@ -969,6 +970,30 @@ def requirements_file_specs(*, path: Path) -> Iterator[RequirementSpec]:
             name=requirement_name,
             marker=None if markers is None else Marker(str(markers)),
             text=requirement.requirement,
+        )
+
+
+def pyproject_specs(*, path: Path) -> Iterator[RequirementSpec]:
+    """Yield each ``[project]`` dependency in a ``pyproject.toml`` file.
+
+    Only the ``dependencies`` list is read. A file with no ``[project]``
+    table, or one with no ``dependencies`` list, gives no requirements.
+
+    Raise ``ValueError`` for a requirement which cannot be parsed.
+    """
+    with path.open(mode="rb") as pyproject_file:
+        pyproject = tomllib.load(pyproject_file)
+
+    # ``tomllib`` gives ``dict[str, Any]``, so the values it holds have no
+    # type. ``Requirement`` rejects anything which is not a requirement
+    # string.
+    project_table = pyproject.get("project", {})
+    for text in project_table.get("dependencies", []):
+        requirement = Requirement(text)
+        yield RequirementSpec(
+            name=requirement.name,
+            marker=requirement.marker,
+            text=text,
         )
 
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1184,6 +1184,61 @@ def test_requirements_file_specs_egg_fragment_names_requirement(
     assert [spec.name for spec in specs] == ["foobar", "repo"]
 
 
+def test_pyproject_specs(tmp_path: Path) -> None:
+    """Each ``[project]`` dependency gives a record of the requirement."""
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        data=textwrap.dedent(
+            text="""\
+            [project]
+            name = "spam"
+            dependencies = [
+                "foobar==1",
+                'barfoo==2; python_version < "2.0"',
+            ]
+            """,
+        ),
+    )
+
+    specs = list(common.pyproject_specs(path=pyproject))
+
+    assert [spec.name for spec in specs] == ["foobar", "barfoo"]
+    assert [spec.text for spec in specs] == [
+        "foobar==1",
+        'barfoo==2; python_version < "2.0"',
+    ]
+    assert specs[0].marker is None
+    assert specs[1].marker is not None
+    assert not specs[1].marker.evaluate()
+
+
+def test_pyproject_specs_no_project_table(tmp_path: Path) -> None:
+    """A file with no ``[project]`` table declares no requirements."""
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(data='[build-system]\nrequires = ["setuptools"]\n')
+
+    assert not list(common.pyproject_specs(path=pyproject))
+
+
+def test_pyproject_specs_no_dependencies(tmp_path: Path) -> None:
+    """A ``[project]`` table with no dependencies declares no requirements."""
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(data='[project]\nname = "spam"\n')
+
+    assert not list(common.pyproject_specs(path=pyproject))
+
+
+def test_pyproject_specs_invalid_requirement(tmp_path: Path) -> None:
+    """A dependency which is not a requirement string gives an error."""
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        data='[project]\nname = "spam"\ndependencies = ["foo bar =="]\n',
+    )
+
+    with pytest.raises(expected_exception=ValueError, match="foo bar =="):
+        list(common.pyproject_specs(path=pyproject))
+
+
 def _editable_line(directory: Path) -> str:
     """Return an ``-e`` requirement line for a directory.
 


### PR DESCRIPTION
Part of #97 ("Add a class for requirements from `pyproject.toml`").

Adds `pyproject_specs`, which yields the `[project] dependencies` of a `pyproject.toml` file as the same `RequirementSpec` records that `requirements_file_specs` gives. Both sources can then be filtered by `find_required_modules` (#633).

- Uses `pip._internal.utils.compat.tomllib`, which pip already resolves to `tomllib` on 3.11+ and its vendored `tomli` on 3.10, so there is no new dependency and no version branch to exclude from coverage.
- Only the `dependencies` list is read. A missing `[project]` table or `dependencies` list gives no requirements. An unparseable requirement raises `ValueError`, as the requirements file reader does.
- Not yet wired to the command line. Wiring a `--pyproject` style option, and reading `optional-dependencies`, are left for later steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)