### PR TITLE
Accept a pyproject.toml file as --requirements-file

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,10 @@ Release History
 
 3.1.0
 
+- Both commands accept a ``pyproject.toml`` file as ``--requirements-file``.
+  The ``dependencies`` list of its ``[project]`` table is then checked in
+  place of a requirements file, so a project which declares its dependencies
+  there no longer needs to export them to a requirements file first.
 - Both commands gain a ``--use-gitignore`` option. Files and directories which
   a ``.gitignore`` file ignores are then skipped, as they are by Git. Each
   ``.gitignore`` file from the repository root down applies.

--- a/README.rst
+++ b/README.rst
@@ -184,7 +184,14 @@ Using pyproject.toml instead of requirements.txt
 
 If your project uses ``pyproject.toml``, there are multiple ways to use ``pip-check-reqs`` with it.
 
-One way is to use an external tool to convert ``pyproject.toml`` to ``requirements.txt``::
+The simplest way is to give the ``pyproject.toml`` file as the requirements file.
+The ``dependencies`` list of its ``[project]`` table is then checked::
+
+    pip-missing-reqs --requirements-file pyproject.toml src
+    pip-extra-reqs --requirements-file pyproject.toml src
+
+Optional dependencies and other tables are not read.
+For those, one way is to use an external tool to convert ``pyproject.toml`` to ``requirements.txt``::
 
     # requires `pip install pdm`
     pdm export --pyproject > requirements.txt

--- a/pip_check_reqs/common.py
+++ b/pip_check_reqs/common.py
@@ -997,6 +997,17 @@ def pyproject_specs(*, path: Path) -> Iterator[RequirementSpec]:
         )
 
 
+def requirement_specs(*, path: Path) -> Iterator[RequirementSpec]:
+    """Yield each requirement a file declares.
+
+    A file named ``pyproject.toml`` is read as a project file, and any other
+    file as a requirements file.
+    """
+    if path.name == "pyproject.toml":
+        return pyproject_specs(path=path)
+    return requirements_file_specs(path=path)
+
+
 def find_required_modules(
     *,
     ignore_requirements_function: Callable[[str], bool],

--- a/pip_check_reqs/find_extra_reqs.py
+++ b/pip_check_reqs/find_extra_reqs.py
@@ -44,7 +44,7 @@ def find_extra_reqs(
     explicit = common.find_required_modules(
         ignore_requirements_function=ignore_requirements_function,
         skip_incompatible=skip_incompatible,
-        specs=common.requirements_file_specs(path=requirements_filename),
+        specs=common.requirement_specs(path=requirements_filename),
     )
 
     extras: list[str] = []
@@ -79,7 +79,10 @@ def main(arguments: list[str] | None = None) -> None:
         type=Path,
         metavar="PATH",
         default=Path("requirements.txt"),
-        help='path to the requirements file (defaults to "requirements.txt")',
+        help=(
+            "path to the requirements file, or to a pyproject.toml file "
+            '(defaults to "requirements.txt")'
+        ),
     )
     parser.add_argument(
         "-f",

--- a/pip_check_reqs/find_missing_reqs.py
+++ b/pip_check_reqs/find_missing_reqs.py
@@ -68,7 +68,7 @@ def find_missing_reqs(
         explicit |= common.find_required_modules(
             ignore_requirements_function=common.ignorer(ignore_cfg=[]),
             skip_incompatible=False,
-            specs=common.requirements_file_specs(path=filename),
+            specs=common.requirement_specs(path=filename),
         )
 
     _report_uninstalled_imports(
@@ -153,7 +153,8 @@ def main(arguments: list[str] | None = None) -> None:
         type=Path,
         action="append",
         help=(
-            "path to a requirements file; may be repeated "
+            "path to a requirements file, or to a pyproject.toml file; "
+            "may be repeated "
             '(defaults to "requirements.txt")'
         ),
     )

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1239,6 +1239,28 @@ def test_pyproject_specs_invalid_requirement(tmp_path: Path) -> None:
         list(common.pyproject_specs(path=pyproject))
 
 
+def test_requirement_specs_pyproject(tmp_path: Path) -> None:
+    """A file named ``pyproject.toml`` is read as a project file."""
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        data='[project]\nname = "spam"\ndependencies = ["foobar==1"]\n',
+    )
+
+    specs = list(common.requirement_specs(path=pyproject))
+
+    assert [spec.name for spec in specs] == ["foobar"]
+
+
+def test_requirement_specs_requirements_file(tmp_path: Path) -> None:
+    """Any other file is read as a requirements file."""
+    requirements_file = tmp_path / "requirements.txt"
+    requirements_file.write_text(data="foobar==1\n")
+
+    specs = list(common.requirement_specs(path=requirements_file))
+
+    assert [spec.name for spec in specs] == ["foobar"]
+
+
 def _editable_line(directory: Path) -> str:
     """Return an ``-e`` requirement line for a directory.
 

--- a/tests/test_find_extra_reqs.py
+++ b/tests/test_find_extra_reqs.py
@@ -136,6 +136,39 @@ def test_main_failure(
     assert caplog.records[1].message == expected_message
 
 
+def test_main_pyproject_requirements_file(
+    *,
+    caplog: pytest.LogCaptureFixture,
+    tmp_path: Path,
+) -> None:
+    """A ``pyproject.toml`` file given as the requirements file is read."""
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        data='[project]\nname = "spam"\ndependencies = ["pip", "pytest"]\n',
+    )
+
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    (source_dir / "source.py").write_text("import pip\n")
+
+    caplog.set_level(logging.WARNING)
+
+    with pytest.raises(SystemExit) as excinfo:
+        find_extra_reqs.main(
+            arguments=[
+                "--requirements-file",
+                str(pyproject),
+                str(source_dir),
+            ],
+        )
+
+    assert excinfo.value.code == 1
+    assert [record.message for record in caplog.records] == [
+        "Extra requirements:",
+        f"pytest in {pyproject}",
+    ]
+
+
 def test_main_ignore_requirement(
     *,
     caplog: pytest.LogCaptureFixture,

--- a/tests/test_find_missing_reqs.py
+++ b/tests/test_find_missing_reqs.py
@@ -229,6 +229,39 @@ def test_main_multiple_requirements_files(
     assert not caplog.records
 
 
+def test_main_pyproject_requirements_file(
+    *,
+    caplog: pytest.LogCaptureFixture,
+    tmp_path: Path,
+) -> None:
+    """A ``pyproject.toml`` file given as the requirements file is read."""
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        data='[project]\nname = "spam"\ndependencies = ["pip"]\n',
+    )
+
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    (source_dir / "source.py").write_text("import pip\nimport pytest\n")
+
+    caplog.set_level(logging.WARNING)
+
+    with pytest.raises(SystemExit) as excinfo:
+        find_missing_reqs.main(
+            arguments=[
+                "--requirements-file",
+                str(pyproject),
+                str(source_dir),
+            ],
+        )
+
+    assert excinfo.value.code == 1
+    assert [record.message for record in caplog.records] == [
+        "Missing requirements:",
+        f"{source_dir / 'source.py'}:2 dist=pytest module=pytest",
+    ]
+
+
 def test_main_failure(
     *,
     caplog: pytest.LogCaptureFixture,


### PR DESCRIPTION
Both commands now accept a file named `pyproject.toml` as `--requirements-file`. Its `[project]` `dependencies` list is read through the `pyproject_specs` reader added in #634, via a new `common.requirement_specs` dispatcher which falls back to the requirements-file reader for any other file. Unit tests cover the dispatcher, and each command gains an end-to-end test reporting a missing or extra requirement from a `pyproject.toml` file. The README now leads with this form and notes that optional dependencies and other tables are not read, and the changelog has an entry under 3.1.0.

Part of #97.

🤖 Generated with [Claude Code](https://claude.com/claude-code)