### PR TITLE
Use prek to run linters

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,63 +18,42 @@ jobs:
   build:
     strategy:
       matrix:
-        uv-resolution: ["highest", "lowest-direct"]
-        # The minimum version should be represented in pyproject.toml.
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.14"]
         os: [ubuntu-latest, windows-latest]
+        hook-stage: [pre-commit, pre-push, manual]
 
     runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: "Install uv"
         uses: astral-sh/setup-uv@v10.0.1
         with:
-          python-version: ${{ matrix.python-version }}
+          enable-cache: true
+          cache-dependency-glob: "**/*requirements.txt"
 
       - name: "Lint"
-        # Use bash to ensure the step fails if any command fails.
-        # PowerShell does not fail on intermediate command failures by default.
-        shell: bash
-        run: |
-          uv run --resolution=${{ matrix.uv-resolution }} --extra dev mypy .
-          uv run --resolution=${{ matrix.uv-resolution }} --extra dev ruff check .
-          uv run --resolution=${{ matrix.uv-resolution }} --extra dev ruff format --check .
-          uv run --resolution=${{ matrix.uv-resolution }} --extra dev pip-extra-reqs pip_check_reqs
-          uv run --resolution=${{ matrix.uv-resolution }} --extra dev pip-missing-reqs pip_check_reqs
-          uv run --resolution=${{ matrix.uv-resolution }} --extra dev pylint pip_check_reqs tests
-          uv run --resolution=${{ matrix.uv-resolution }} --extra dev pyroma --min=10 .
-          uv run --resolution=${{ matrix.uv-resolution }} --extra dev pyproject-fmt --check .
-          uv run --resolution=${{ matrix.uv-resolution }} --extra dev pyright .
-          uv run --resolution=${{ matrix.uv-resolution }} --extra dev actionlint
-
-  prose:
-    name: Vale
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: "Install uv"
-        uses: astral-sh/setup-uv@v10.0.1
-
-      # ai-tells bans em dashes and other AI-written prose patterns.  The style package is pinned in
-      # ``.vale.ini`` and ``vale sync`` downloads it into the gitignored
-      # ``styles`` directory.  Vale needs ``rst2html`` from Docutils on the
-      # ``PATH`` to parse reStructuredText.
-      - name: "Lint prose"
-        run: |
-          uvx --with docutils vale@3.13.0.0 sync
-          git ls-files '*.rst' '*.md' | xargs --no-run-if-empty uvx --with docutils vale@3.13.0.0
+        uses: j178/prek-action@v3.0.0
+        with:
+          prek-version: 0.5.2
+          cache: false
+          extra-args: >-
+            --all-files --hook-stage ${{ matrix.hook-stage }} --verbose
+        env:
+          UV_NO_CACHE: "1"
+          UV_PYTHON: ${{ matrix.python-version }}
 
   completion-lint:
-    needs: [build, prose]
+    needs: build
     runs-on: ubuntu-latest
     if: always()
     steps:
       - name: Check matrix job status
         run: |
-          if ! ${{ needs.build.result == 'success' && needs.prose.result == 'success' }}; then
+          if ! ${{ needs.build.result == 'success' }}; then
             echo "One or more matrix jobs failed"
             exit 1
           fi

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -93,18 +93,18 @@ Release History
 
 2.5.1
 
-- Fix an issue with importing `__main__`.
+- Fix an issue with importing ``__main__``.
 - Fix an issue with importing packages with periods in their names.
 
 2.5.0
 
 - Support Python 3.10.
 - Remove support for Python 3.8.
-- Bump `pip` requirement to 23.2.
+- Bump ``pip`` requirement to 23.2.
 
 2.4.4
 
-- Bump `packaging` requirement to >= 20.5. Older versions of `pip-check-reqs` may be broken with the previously-specified version requirements.
+- Bump ``packaging`` requirement to >= 20.5. Older versions of ``pip-check-reqs`` may be broken with the previously-specified version requirements.
 
 2.4.3
 
@@ -113,12 +113,12 @@ Release History
 2.4.2
 
 - Added support for Python 3.11.
-- Added `python_requires` to metadata; from now on, releases of
-  `pip-check-reqs` are marked as compatible with Python 3.8.0 and up.
-- Made `--version` flag show interpretter version and path to the package which
+- Added ``python_requires`` to metadata; from now on, releases of
+  ``pip-check-reqs`` are marked as compatible with Python 3.8.0 and up.
+- Made ``--version`` flag show interpretter version and path to the package which
   pip-check-reqs is running from, similar to information shown by `pip
   --version`.
-- `-V` is now an alias of `--version`.
+- ``-V`` is now an alias of ``--version``.
 
 2.3.2
 
@@ -126,7 +126,7 @@ Release History
 
 2.3.1
 
-- Fixed `--skip-incompatible` skipping other requirements too.
+- Fixed ``--skip-incompatible`` skipping other requirements too.
 - Support pip >= 21.3
 
 2.3.0
@@ -136,7 +136,7 @@ Release History
 2.2.2
 
 - AST parsing failures will now report tracebacks with a proper filename for
-  the parsed frame, instead of `<unknown>`.
+  the parsed frame, instead of ``<unknown>``.
 
 2.2.1
 
@@ -145,13 +145,13 @@ Release History
 
 2.2.0
 
-- Added `--skip-incompatible` flag to `pip-extra-reqs`, which makes it ignore
+- Added ``--skip-incompatible`` flag to ``pip-extra-reqs``, which makes it ignore
   requirements with environment markers that are incompatible with the current
   environment.
-- Added `--requirements-file` flag to `pip-extra-reqs` and `pip-missing-reqs`
+- Added ``--requirements-file`` flag to ``pip-extra-reqs`` and ``pip-missing-reqs``
   commands. This flag makes it possible to specify a path to the requirements
-  file. Previously, `"requirements.txt"` was always used.
-- Fixed some of the logs not being visible with `-d` and `-v` flags.
+  file. Previously, ``"requirements.txt"`` was always used.
+- Fixed some of the logs not being visible with ``-d`` and ``-v`` flags.
 
 2.1.1
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,6 +1,63 @@
 Contributing
 ============
 
+Setting up a development environment
+------------------------------------
+
+Install the project and its development dependencies with `uv`_:
+
+.. code-block:: console
+
+   $ uv sync --extra dev
+
+Pylint's spelling checker requires the ``enchant`` C library.
+Install it on macOS with `Homebrew`_:
+
+.. code-block:: console
+
+   $ brew install enchant
+
+and on Ubuntu with ``apt``:
+
+.. code-block:: console
+
+   $ apt-get install -y enchant
+
+Install ``prek`` hooks:
+
+.. code-block:: console
+
+   $ uv run --extra dev prek install
+
+.. _uv: https://docs.astral.sh/uv/
+.. _Homebrew: https://brew.sh
+
+Linting
+-------
+
+Run lint tools either by committing, or with:
+
+.. code-block:: console
+
+   $ uv run --extra dev prek run --all-files --hook-stage pre-commit --verbose
+   $ uv run --extra dev prek run --all-files --hook-stage pre-push --verbose
+   $ uv run --extra dev prek run --all-files --hook-stage manual --verbose
+
+Running tests
+-------------
+
+Run ``pytest``:
+
+.. code-block:: console
+
+   $ uv run --extra dev pytest
+
+Continuous integration
+----------------------
+
+Tests and lint checks run on GitHub Actions.
+The configuration for this is in ``.github/workflows/``.
+
 Release process
 ---------------
 

--- a/README.rst
+++ b/README.rst
@@ -108,15 +108,15 @@ application source ("sample" in the above examples). The requirements for
 those tests generally should not be in the requirements.txt file, and you
 don't want this tool to generate false hits for those.
 
-You may exclude those test files from your check using the `--ignore-file`
-option (shorthand is `-f`). Multiple instances of the option are allowed.
+You may exclude those test files from your check using the ``--ignore-file``
+option (shorthand is ``-f``). Multiple instances of the option are allowed.
 
 A virtual environment within the checked directory is skipped automatically.
 A directory is treated as a virtual environment when it contains a
 ``pyvenv.cfg`` file, which ``venv``, ``virtualenv`` and ``uv`` all create.
 
-Files which Git ignores can be skipped too, with `--use-gitignore` (shorthand
-is `-g`)::
+Files which Git ignores can be skipped too, with ``--use-gitignore`` (shorthand
+is ``-g``)::
 
     pip-missing-reqs --use-gitignore sample
     pip-extra-reqs --use-gitignore sample
@@ -131,7 +131,7 @@ Excluding modules from the check
 
 If your project has modules which are conditionally imported, or requirements
 which are conditionally included, you may exclude certain modules from the
-check by name (or glob pattern) using `--ignore-module` (shorthand is `-m`)::
+check by name (or glob pattern) using ``--ignore-module`` (shorthand is ``-m``)::
 
     # ignore the module spam
     pip-missing-reqs --ignore-module=spam sample
@@ -148,7 +148,7 @@ loaded by an entry point, is installed and used without an ``import``
 statement. ``pip-extra-reqs`` reports such a requirement as extra.
 
 You may exclude a requirement from the check by name (or glob pattern) using
-`--ignore-requirement` (shorthand is `-r`). The name is matched as it is
+``--ignore-requirement`` (shorthand is ``-r``). The name is matched as it is
 written in the requirements file. Multiple instances of the option are
 allowed::
 
@@ -168,7 +168,7 @@ not be listed.
 Some files must list every distribution, whether the source imports it or
 not. A constraints file, given to pip with ``-c``, which pins a minimum
 version of every distribution in a test environment is one. To check such a
-file, pass `--transitive` (shorthand is `-t`). The dependencies of each
+file, pass ``--transitive`` (shorthand is ``-t``). The dependencies of each
 distribution the source imports are then followed, recursively, and any
 which is not listed is reported with the distribution which requires it::
 
@@ -202,7 +202,7 @@ For those, one way is to use an external tool to convert ``pyproject.toml`` to `
 Then you can use ``pip-missing-reqs`` and ``pip-extra-reqs`` as usual.
 
 Another way is to use a ``requirements.txt`` file within your ``pyproject.toml`` file,
-for example with the `setuptools` build backend:
+for example with the ``setuptools`` build backend:
 
 .. code:: toml
 

--- a/prek.toml
+++ b/prek.toml
@@ -1,0 +1,254 @@
+# Configuration file for `prek`, a git hook framework written in Rust.
+# See https://prek.j178.dev for more information.
+#:schema https://www.schemastore.org/prek.json
+
+fail_fast = true
+default_install_hook_types = [
+  "pre-commit",
+  "pre-push"
+  ]
+
+[[repos]]
+repo = "meta"
+hooks = [
+  {
+    id = "check-useless-excludes",
+    stages = ["pre-commit"]
+  }
+]
+
+[[repos]]
+repo = "https://github.com/pre-commit/pre-commit-hooks"
+rev = "v6.0.0"
+hooks = [
+  {
+    id = "check-added-large-files",
+    stages = ["pre-commit"]
+  },
+  {
+    id = "check-case-conflict",
+    stages = ["pre-commit"]
+  },
+  {
+    id = "check-executables-have-shebangs",
+    stages = ["pre-commit"]
+  },
+  {
+    id = "check-merge-conflict",
+    stages = ["pre-commit"]
+  },
+  {
+    id = "check-shebang-scripts-are-executable",
+    stages = ["pre-commit"]
+  },
+  {
+    id = "check-symlinks",
+    stages = ["pre-commit"]
+  },
+  {
+    id = "check-json",
+    stages = ["pre-commit"]
+  },
+  {
+    id = "check-toml",
+    stages = ["pre-commit"]
+  },
+  {
+    id = "check-vcs-permalinks",
+    stages = ["pre-commit"]
+  },
+  {
+    id = "check-yaml",
+    stages = ["pre-commit"]
+  },
+  {
+    id = "end-of-file-fixer",
+    stages = ["pre-commit"]
+  },
+  {
+    id = "file-contents-sorter",
+    files = 'spelling_private_dict\.txt$',
+    stages = ["pre-commit"]
+  },
+  {
+    id = "trailing-whitespace",
+    stages = ["pre-commit"]
+  }
+]
+
+[[repos]]
+repo = "https://github.com/pre-commit/pygrep-hooks"
+rev = "v1.10.0"
+hooks = [
+  {
+    id = "rst-directive-colons",
+    stages = ["pre-commit"]
+  },
+  {
+    id = "rst-inline-touching-normal",
+    stages = ["pre-commit"]
+  },
+  {
+    id = "text-unicode-replacement-char",
+    stages = ["pre-commit"]
+  },
+  {
+    id = "rst-backticks",
+    stages = ["pre-commit"]
+  }
+]
+
+[[repos]]
+repo = "local"
+hooks = [
+  {
+    id = "actionlint",
+    name = "actionlint",
+    entry = "uv run --extra=dev actionlint",
+    language = "python",
+    pass_filenames = false,
+    types_or = ["yaml"],
+    additional_dependencies = ["uv==0.12.10"],
+    stages = ["pre-commit"]
+  },
+  {
+    id = "shellcheck",
+    name = "shellcheck",
+    entry = "uv run --extra=dev shellcheck --shell=bash",
+    language = "python",
+    types_or = ["shell"],
+    additional_dependencies = ["uv==0.12.10"],
+    stages = ["pre-commit"]
+  },
+  {
+    id = "shfmt",
+    name = "shfmt",
+    entry = "uv run --extra=dev shfmt --write --space-redirects --indent=4",
+    language = "python",
+    types_or = ["shell"],
+    additional_dependencies = ["uv==0.12.10"],
+    stages = ["pre-commit"]
+  },
+  {
+    id = "ruff-check-fix",
+    name = "Ruff check fix",
+    entry = "uv run --extra=dev -m ruff check --fix",
+    language = "python",
+    types_or = ["python"],
+    additional_dependencies = ["uv==0.12.10"],
+    stages = ["pre-commit"]
+  },
+  {
+    id = "ruff-format-fix",
+    name = "Ruff format",
+    entry = "uv run --extra=dev -m ruff format",
+    language = "python",
+    types_or = ["python"],
+    additional_dependencies = ["uv==0.12.10"],
+    stages = ["pre-commit"]
+  },
+  {
+    id = "pyproject-fmt-fix",
+    name = "pyproject-fmt",
+    entry = "uv run --extra=dev pyproject-fmt",
+    language = "python",
+    types_or = ["toml"],
+    files = "pyproject.toml",
+    additional_dependencies = ["uv==0.12.10"],
+    stages = ["pre-commit"]
+  },
+  {
+    id = "pyroma",
+    name = "pyroma",
+    entry = "uv run --extra=dev -m pyroma --min 10 .",
+    language = "python",
+    pass_filenames = false,
+    types_or = ["toml"],
+    additional_dependencies = ["uv==0.12.10"],
+    stages = ["pre-commit"]
+  },
+  {
+    id = "pip-extra-reqs",
+    name = "pip-extra-reqs",
+    entry = "uv run --extra=dev pip-extra-reqs pip_check_reqs",
+    language = "python",
+    pass_filenames = false,
+    types_or = [
+      "python",
+      "text"
+    ],
+    additional_dependencies = ["uv==0.12.10"],
+    stages = ["pre-commit"]
+  },
+  {
+    id = "pip-missing-reqs",
+    name = "pip-missing-reqs",
+    entry = "uv run --extra=dev pip-missing-reqs pip_check_reqs",
+    language = "python",
+    pass_filenames = false,
+    types_or = [
+      "python",
+      "text"
+    ],
+    additional_dependencies = ["uv==0.12.10"],
+    stages = ["pre-commit"]
+  },
+  {
+    id = "vale-sync",
+    name = "vale sync",
+    entry = "uv run --extra=dev vale sync",
+    language = "python",
+    pass_filenames = false,
+    files = '(\.(rst|md)$|^\.vale\.ini$)',
+    additional_dependencies = ["uv==0.12.10"],
+    stages = ["pre-commit"]
+  },
+  {
+    id = "vale",
+    name = "vale",
+    entry = "uv run --extra=dev vale",
+    language = "python",
+    types_or = [
+      "rst",
+      "markdown"
+    ],
+    require_serial = true,
+    additional_dependencies = ["uv==0.12.10"],
+    stages = ["pre-commit"]
+  },
+  {
+    id = "mypy",
+    name = "mypy",
+    stages = ["pre-push"],
+    entry = "uv run --extra=dev -m mypy .",
+    language = "python",
+    types_or = [
+      "python",
+      "toml"
+    ],
+    pass_filenames = false,
+    additional_dependencies = ["uv==0.12.10"]
+  },
+  {
+    id = "pyright",
+    name = "pyright",
+    stages = ["pre-push"],
+    entry = "uv run --extra=dev -m pyright .",
+    language = "python",
+    types_or = [
+      "python",
+      "toml"
+    ],
+    pass_filenames = false,
+    additional_dependencies = ["uv==0.12.10"]
+  },
+  {
+    id = "pylint",
+    name = "pylint",
+    entry = "uv run --extra=dev -m pylint pip_check_reqs tests",
+    language = "python",
+    stages = ["manual"],
+    pass_filenames = false,
+    additional_dependencies = ["uv==0.12.10"]
+  }
+]

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,7 @@
 actionlint-py==1.7.12.24
+docutils==0.23
 mypy==2.3.1
+prek==0.5.2
 pyenchant==3.3.0
 pylint==4.0.8
 pyproject-fmt==2.29.3
@@ -9,3 +11,9 @@ pytest==9.1.1
 pytest-cov==7.1.0
 ruamel.yaml==0.19.1
 ruff==0.16.6
+# We add shellcheck-py not only for shell scripts, but also because having it
+# installed means that ``actionlint-py`` will use it to lint shell commands in
+# GitHub workflow files.
+shellcheck-py==0.11.0.1
+shfmt-py==4.1.0
+vale==3.20.0.0


### PR DESCRIPTION
Adds a `prek.toml` which runs the existing lint tools as pre-commit, pre-push, and manual hooks, mirroring the setup in [VWS-Python/vws-python](https://github.com/VWS-Python/vws-python). The lint workflow now uses the prek GitHub Action with a matrix over hook stage and OS, and the separate Vale job is folded into the hooks. Dev requirements gain prek, vale, docutils, shellcheck-py, and shfmt-py. CONTRIBUTING.rst documents environment setup and how to install and run the hooks. A few single-backtick inline code spans in CHANGELOG.rst and README.rst become double backticks to satisfy the new rst-backticks hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)