### PR TITLE
Configure checker-specific ignore comments

### DIFF
--- a/pip_check_reqs/common.py
+++ b/pip_check_reqs/common.py
@@ -54,8 +54,7 @@ def cached_resolve_path(path: Path) -> Path:
 @cache
 def get_packages_info() -> list[_PackageInfo]:
     all_pkgs: list[str] = [
-        dist.metadata["Name"]  # pyright: ignore[reportUnknownMemberType]
-        for dist in importlib.metadata.distributions()
+        dist.metadata["Name"] for dist in importlib.metadata.distributions()
     ]
 
     return list(search_packages_info(query=all_pkgs, include_files=True))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,6 +175,8 @@ strict = true
 
 [tool.pyright]
 typeCheckingMode = "strict"
+enableTypeIgnoreComments = false
+reportUnnecessaryTypeIgnoreComment = true
 
 [tool.coverage]
 run.branch = true


### PR DESCRIPTION
Configure Pyright to ignore Mypy `# type: ignore` comments and report unnecessary Pyright-specific ignores. This keeps suppression ownership checker-specific.