### PR TITLE
Use one sentence per line in documentation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,69 +5,47 @@ Release History
 3.1.0
 
 - Both commands accept a ``pyproject.toml`` file as ``--requirements-file``.
-  The ``dependencies`` list of its ``[project]`` table is then checked in
-  place of a requirements file, so a project which declares its dependencies
-  there no longer needs to export them to a requirements file first.
-- Both commands gain a ``--use-gitignore`` option. Files and directories which
-  a ``.gitignore`` file ignores are then skipped, as they are by Git. Each
-  ``.gitignore`` file from the repository root down applies.
-- A directory within the checked path which cannot be read now reports a
-  command line error. It was previously skipped silently, which hid any
-  missing requirement imported only by the files within it.
-- ``pip-missing-reqs`` gains a ``--transitive`` option. It also reports the
-  dependencies of the distributions the source imports, followed recursively,
-  which no requirements file lists. This checks a constraints file which must
-  pin every distribution in an environment.
-- A virtual environment within the checked directory is now skipped. A
-  directory is treated as a virtual environment when it contains a
-  ``pyvenv.cfg`` file. Both commands previously scanned every installed
-  distribution in such an environment as if it were project source.
-- ``pip-missing-reqs`` accepts ``--requirements-file`` more than once, so
-  requirements split across several files are checked as one set.
-- A missing requirements file or source path now reports a concise command
-  line error. A missing requirements file previously surfaced an internal
-  pip exception, and a missing source path was silently ignored.
-- A source file which cannot be parsed now reports a command line error
-  naming the file and the line at fault. It previously showed a
-  ``SyntaxError`` traceback.
-- An import from a submodule that does not exist is no longer attributed to
-  an installed parent distribution, which removed a class of false positives.
-- A requirement with no distribution name, such as ``-e .`` or a bare
-  ``git+ssh://...`` URL, is now matched to the installed distribution which
-  was installed from that directory or URL. When no such distribution is
-  installed, both commands report an error asking for an ``#egg=<name>``
-  fragment. They previously crashed with an ``AssertionError``.
-- A requirement which pip cannot read, such as a directory with no
-  ``pyproject.toml``, now reports a command line error. It previously showed
-  a pip traceback.
-- On Windows, an ignore glob no longer crashes with a ``ValueError`` when a
-  source file is on a different drive to the working directory.
-- Both commands now warn when they are run from outside the active virtual
-  environment, as the results then describe the environment the command is
-  installed in rather than the active one.
-- ``pip-missing-reqs`` now warns about an import of a module which is not
-  installed, giving the file and line. Such an import was silently ignored,
-  so a package uninstalled by mistake, or an import of the wrong name, gave
-  no output at all. A module which the scanned source provides is not
-  reported, and ``--ignore-module`` silences the warning.
-- ``pip-missing-reqs`` no longer warns about an import which is not
-  installed when it is made in a ``try`` block which catches
-  ``ImportError``. Such an import is a soft dependency which the code
-  tolerates being absent.
-- A requirement installed in editable mode, with ``pip install -e``, is now
-  matched to the modules it provides. ``pip-extra-reqs`` reported such a
-  requirement as extra even when the code imported it, and
-  ``pip-missing-reqs`` did not report an import of one which was not
-  required.
-- ``pip-extra-reqs`` no longer reports a requirement which is not installed
-  as an extra requirement. Which modules a requirement provides is only
-  known from the installed distribution, so an uninstalled requirement was
-  reported as extra even when the code imported it. It is now reported as a
-  warning saying that it could not be checked.
+  The ``dependencies`` list of its ``[project]`` table is then checked in place of a requirements file, so a project which declares its dependencies there no longer needs to export them to a requirements file first.
+- Both commands gain a ``--use-gitignore`` option.
+  Files and directories which a ``.gitignore`` file ignores are then skipped, as they are by Git.
+  Each ``.gitignore`` file from the repository root down applies.
+- A directory within the checked path which cannot be read now reports a command line error.
+  It was previously skipped silently, which hid any missing requirement imported only by the files within it.
+- ``pip-missing-reqs`` gains a ``--transitive`` option.
+  It also reports the dependencies of the distributions the source imports, followed recursively, which no requirements file lists.
+  This checks a constraints file which must pin every distribution in an environment.
+- A virtual environment within the checked directory is now skipped.
+  A directory is treated as a virtual environment when it contains a ``pyvenv.cfg`` file.
+  Both commands previously scanned every installed distribution in such an environment as if it were project source.
+- ``pip-missing-reqs`` accepts ``--requirements-file`` more than once, so requirements split across several files are checked as one set.
+- A missing requirements file or source path now reports a concise command line error.
+  A missing requirements file previously surfaced an internal pip exception, and a missing source path was silently ignored.
+- A source file which cannot be parsed now reports a command line error naming the file and the line at fault.
+  It previously showed a ``SyntaxError`` traceback.
+- An import from a submodule that does not exist is no longer attributed to an installed parent distribution, which removed a class of false positives.
+- A requirement with no distribution name, such as ``-e .`` or a bare ``git+ssh://...``
+  URL, is now matched to the installed distribution which was installed from that directory or URL.
+  When no such distribution is installed, both commands report an error asking for an ``#egg=<name>`` fragment.
+  They previously crashed with an ``AssertionError``.
+- A requirement which pip cannot read, such as a directory with no ``pyproject.toml``, now reports a command line error.
+  It previously showed a pip traceback.
+- On Windows, an ignore glob no longer crashes with a ``ValueError`` when a source file is on a different drive to the working directory.
+- Both commands now warn when they are run from outside the active virtual environment, as the results then describe the environment the command is installed in rather than the active one.
+- ``pip-missing-reqs`` now warns about an import of a module which is not installed, giving the file and line.
+  Such an import was silently ignored, so a package uninstalled by mistake, or an import of the wrong name, gave no output at all.
+  A module which the scanned source provides is not reported, and ``--ignore-module`` silences the warning.
+- ``pip-missing-reqs`` no longer warns about an import which is not installed when it is made in a ``try`` block which catches ``ImportError``.
+  Such an import is a soft dependency which the code tolerates being absent.
+- A requirement installed in editable mode, with ``pip install -e``, is now matched to the modules it provides.
+  ``pip-extra-reqs`` reported such a requirement as extra even when the code imported it, and ``pip-missing-reqs`` did not report an import of one which was not required.
+- ``pip-extra-reqs`` no longer reports a requirement which is not installed as an extra requirement.
+  Which modules a requirement provides is only known from the installed distribution, so an uninstalled requirement was reported as extra even when the code imported it.
+  It is now reported as a warning saying that it could not be checked.
 
 3.0.0
 
-- Drop support for Python 3.9. Python 3.10 or later is now required.
+- Drop support for Python 3.9.
+  Python 3.10 or later is now required.
 - Require pip 26.2 or later.
 - Require packaging 26.2 or later.
 
@@ -104,7 +82,8 @@ Release History
 
 2.4.4
 
-- Bump ``packaging`` requirement to >= 20.5. Older versions of ``pip-check-reqs`` may be broken with the previously-specified version requirements.
+- Bump ``packaging`` requirement to >= 20.5.
+  Older versions of ``pip-check-reqs`` may be broken with the previously-specified version requirements.
 
 2.4.3
 
@@ -113,11 +92,8 @@ Release History
 2.4.2
 
 - Added support for Python 3.11.
-- Added ``python_requires`` to metadata; from now on, releases of
-  ``pip-check-reqs`` are marked as compatible with Python 3.8.0 and up.
-- Made ``--version`` flag show interpretter version and path to the package which
-  pip-check-reqs is running from, similar to information shown by `pip
-  --version`.
+- Added ``python_requires`` to metadata; from now on, releases of ``pip-check-reqs`` are marked as compatible with Python 3.8.0 and up.
+- Made ``--version`` flag show interpretter version and path to the package which pip-check-reqs is running from, similar to information shown by ``pip --version``.
 - ``-V`` is now an alias of ``--version``.
 
 2.3.2
@@ -135,22 +111,18 @@ Release History
 
 2.2.2
 
-- AST parsing failures will now report tracebacks with a proper filename for
-  the parsed frame, instead of ``<unknown>``.
+- AST parsing failures will now report tracebacks with a proper filename for the parsed frame, instead of ``<unknown>``.
 
 2.2.1
 
-- Python source is now always read using utf-8, even if default encoding for
-  reading files is set otherwise.
+- Python source is now always read using utf-8, even if default encoding for reading files is set otherwise.
 
 2.2.0
 
-- Added ``--skip-incompatible`` flag to ``pip-extra-reqs``, which makes it ignore
-  requirements with environment markers that are incompatible with the current
-  environment.
-- Added ``--requirements-file`` flag to ``pip-extra-reqs`` and ``pip-missing-reqs``
-  commands. This flag makes it possible to specify a path to the requirements
-  file. Previously, ``"requirements.txt"`` was always used.
+- Added ``--skip-incompatible`` flag to ``pip-extra-reqs``, which makes it ignore requirements with environment markers that are incompatible with the current environment.
+- Added ``--requirements-file`` flag to ``pip-extra-reqs`` and ``pip-missing-reqs`` commands.
+  This flag makes it possible to specify a path to the requirements file.
+  Previously, ``"requirements.txt"`` was always used.
 - Fixed some of the logs not being visible with ``-d`` and ``-v`` flags.
 
 2.1.1
@@ -174,8 +146,7 @@ Release History
 
 2.0 **renamed package to pip_check_reqs**
 
-- added tool pip-extra-reqs to find packages installed but not used
-  (contributed by Josh Hesketh)
+- added tool pip-extra-reqs to find packages installed but not used (contributed by Josh Hesketh)
 
 1.2.1
 
@@ -226,10 +197,8 @@ Release History
 
 - fixed handling of import from __future__
 - self-tested and added own requirements.txt
-- cleaned up usage to require a file or directory to scan (rather than
-  defaulting to ".")
-- vendored code from pip 1.6dev which fixes bug in search_packages_info
-  until pip 1.6 is released
+- cleaned up usage to require a file or directory to scan (rather than defaulting to ".")
+- vendored code from pip 1.6dev which fixes bug in search_packages_info until pip 1.6 is released
 
 1.1.0
 

--- a/README.rst
+++ b/README.rst
@@ -8,14 +8,10 @@
 pip-check-reqs
 ==============
 
-It happens: you start using a module in your project and it works and you
-don't realise that it's only being included in your `virtualenv`_ because
-it's a dependency of a package you're using. pip-missing-reqs finds those
-modules so you can include them in the `requirements.txt`_ for the project.
+It happens: you start using a module in your project and it works and you don't realise that it's only being included in your `virtualenv`_ because it's a dependency of a package you're using. pip-missing-reqs finds those modules so you can include them in the `requirements.txt`_ for the project.
 
-Alternatively, you have a long-running project that has some packages in
-requirements.txt that are no longer actively used in the codebase. The
-pip-extra-reqs tool will find those modules so you can remove them.
+Alternatively, you have a long-running project that has some packages in requirements.txt that are no longer actively used in the codebase.
+The pip-extra-reqs tool will find those modules so you can remove them.
 
 .. _`virtualenv`: https://virtualenv.pypa.io/en/latest/
 .. _`requirements.txt`: https://pip.pypa.io/en/latest/user_guide.html#requirements-files
@@ -34,59 +30,41 @@ Basic usage, running in your project directory::
     <activate virtualenv for your project>
     pip-missing-reqs --ignore-file=sample/tests/* sample
 
-This will find all imports in the code in "sample" and check that the
-packages those modules belong to are in the requirements.txt file.
+This will find all imports in the code in "sample" and check that the packages those modules belong to are in the requirements.txt file.
 
-If dependencies are split across multiple files, repeat ``--requirements-file``
-to check them together::
+If dependencies are split across multiple files, repeat ``--requirements-file`` to check them together::
 
     pip-missing-reqs --requirements-file=requirements.txt \
         --requirements-file=test-requirements.txt sample
 
-Additionally it is possible to check that there are no dependencies in
-requirements.txt that are then unused in the project::
+Additionally it is possible to check that there are no dependencies in requirements.txt that are then unused in the project::
 
     <activate virtualenv for your project>
     pip-extra-reqs --ignore-file=sample/tests/* sample
 
-This would find anything that is listed in requirements.txt but that is not
-imported by sample.
+This would find anything that is listed in requirements.txt but that is not imported by sample.
 
-``pip-missing-reqs`` learns which requirement provides a module from the
-installed distribution, so an import of a module which is not installed
-cannot be traced to a requirement. It warns about each such import, giving
-the file and line, rather than passing over it. Silence a warning with
-``--ignore-module`` if the import is conditional, or if the module comes
-from a path which you do not give to ``pip-missing-reqs``.
+``pip-missing-reqs`` learns which requirement provides a module from the installed distribution, so an import of a module which is not installed cannot be traced to a requirement.
+It warns about each such import, giving the file and line, rather than passing over it.
+Silence a warning with ``--ignore-module`` if the import is conditional, or if the module comes from a path which you do not give to ``pip-missing-reqs``.
 
-An import in a ``try`` block which catches ``ImportError`` is a soft
-dependency: the code runs whether or not the module is installed.
-``pip-missing-reqs`` does not warn about such an import when the module is
-not installed::
+An import in a ``try`` block which catches ``ImportError`` is a soft dependency: the code runs whether or not the module is installed. ``pip-missing-reqs`` does not warn about such an import when the module is not installed::
 
     try:
         import Levenshtein
     except ImportError:
         Levenshtein = None
 
-``pip-extra-reqs`` learns which modules a requirement provides from the
-installed distribution, so it cannot check a requirement which is not
-installed in the environment. It warns about each such requirement rather
-than reporting it as extra.
+``pip-extra-reqs`` learns which modules a requirement provides from the installed distribution, so it cannot check a requirement which is not installed in the environment.
+It warns about each such requirement rather than reporting it as extra.
 
-A requirement installed in editable mode, with ``pip install -e``, imports
-its modules from the directory it is installed from rather than from a copy
-in ``site-packages``. Both commands read that directory from the install, so
-an editable requirement is checked as any other requirement is. The source
-you give to the commands is the project being checked rather than a
-requirement of it, so a module of that source is not treated as a
-requirement even when the project itself is installed in editable mode.
+A requirement installed in editable mode, with ``pip install -e``, imports its modules from the directory it is installed from rather than from a copy in ``site-packages``.
+Both commands read that directory from the install, so an editable requirement is checked as any other requirement is.
+The source you give to the commands is the project being checked rather than a requirement of it, so a module of that source is not treated as a requirement even when the project itself is installed in editable mode.
 
-A requirement given as a URL or a directory, such as ``-e .`` or
-``git+https://github.com/org/repo.git``, does not name a distribution. When
-the requirement is installed, both commands take the name from the install,
-which records where it came from. Otherwise, name the distribution with an
-``#egg=<name>`` fragment.
+A requirement given as a URL or a directory, such as ``-e .`` or ``git+https://github.com/org/repo.git``, does not name a distribution.
+When the requirement is installed, both commands take the name from the install, which records where it came from.
+Otherwise, name the distribution with an ``#egg=<name>`` fragment.
 
 Sample tox.ini configuration
 ----------------------------
@@ -103,35 +81,29 @@ To make your life easier, copy something like this into your tox.ini::
 Excluding test files (or others) from this check
 ------------------------------------------------
 
-Your test files will sometimes be present in the same directory as your
-application source ("sample" in the above examples). The requirements for
-those tests generally should not be in the requirements.txt file, and you
-don't want this tool to generate false hits for those.
+Your test files will sometimes be present in the same directory as your application source ("sample" in the above examples).
+The requirements for those tests generally should not be in the requirements.txt file, and you don't want this tool to generate false hits for those.
 
-You may exclude those test files from your check using the ``--ignore-file``
-option (shorthand is ``-f``). Multiple instances of the option are allowed.
+You may exclude those test files from your check using the ``--ignore-file`` option (shorthand is ``-f``).
+Multiple instances of the option are allowed.
 
 A virtual environment within the checked directory is skipped automatically.
-A directory is treated as a virtual environment when it contains a
-``pyvenv.cfg`` file, which ``venv``, ``virtualenv`` and ``uv`` all create.
+A directory is treated as a virtual environment when it contains a ``pyvenv.cfg`` file, which ``venv``, ``virtualenv`` and ``uv`` all create.
 
-Files which Git ignores can be skipped too, with ``--use-gitignore`` (shorthand
-is ``-g``)::
+Files which Git ignores can be skipped too, with ``--use-gitignore`` (shorthand is ``-g``)::
 
     pip-missing-reqs --use-gitignore sample
     pip-extra-reqs --use-gitignore sample
 
-Each ``.gitignore`` file from the repository root down to the checked
-directory applies, as it does in Git. A file or directory which one ignores
-is not scanned. A file given directly on the command line is always scanned.
+Each ``.gitignore`` file from the repository root down to the checked directory applies, as it does in Git.
+A file or directory which one ignores is not scanned.
+A file given directly on the command line is always scanned.
 
 
 Excluding modules from the check
 --------------------------------
 
-If your project has modules which are conditionally imported, or requirements
-which are conditionally included, you may exclude certain modules from the
-check by name (or glob pattern) using ``--ignore-module`` (shorthand is ``-m``)::
+If your project has modules which are conditionally imported, or requirements which are conditionally included, you may exclude certain modules from the check by name (or glob pattern) using ``--ignore-module`` (shorthand is ``-m``)::
 
     # ignore the module spam
     pip-missing-reqs --ignore-module=spam sample
@@ -142,15 +114,13 @@ check by name (or glob pattern) using ``--ignore-module`` (shorthand is ``-m``):
 Excluding requirements from the check
 -------------------------------------
 
-A project may need a requirement which its code never imports. A web
-application which lists ``gunicorn`` to serve it, or a plugin which is
-loaded by an entry point, is installed and used without an ``import``
-statement. ``pip-extra-reqs`` reports such a requirement as extra.
+A project may need a requirement which its code never imports.
+A web application which lists ``gunicorn`` to serve it, or a plugin which is loaded by an entry point, is installed and used without an ``import`` statement.
+``pip-extra-reqs`` reports such a requirement as extra.
 
-You may exclude a requirement from the check by name (or glob pattern) using
-``--ignore-requirement`` (shorthand is ``-r``). The name is matched as it is
-written in the requirements file. Multiple instances of the option are
-allowed::
+You may exclude a requirement from the check by name (or glob pattern) using ``--ignore-requirement`` (shorthand is ``-r``).
+The name is matched as it is written in the requirements file.
+Multiple instances of the option are allowed::
 
     # ignore the requirement gunicorn
     pip-extra-reqs --ignore-requirement=gunicorn sample
@@ -162,21 +132,16 @@ Checking transitive dependencies
 --------------------------------
 
 ``pip-missing-reqs`` only looks for the requirements which the source imports.
-A dependency of one of those, which the source does not import itself, need
-not be listed.
+A dependency of one of those, which the source does not import itself, need not be listed.
 
-Some files must list every distribution, whether the source imports it or
-not. A constraints file, given to pip with ``-c``, which pins a minimum
-version of every distribution in a test environment is one. To check such a
-file, pass ``--transitive`` (shorthand is ``-t``). The dependencies of each
-distribution the source imports are then followed, recursively, and any
-which is not listed is reported with the distribution which requires it::
+Some files must list every distribution, whether the source imports it or not.
+A constraints file, given to pip with ``-c``, which pins a minimum version of every distribution in a test environment is one.
+To check such a file, pass ``--transitive`` (shorthand is ``-t``).
+The dependencies of each distribution the source imports are then followed, recursively, and any which is not listed is reported with the distribution which requires it::
 
     pip-missing-reqs --requirements-file=minimum-constraints.txt --transitive sample
 
-A dependency is only followed when its environment marker holds in the
-environment which ``pip-missing-reqs`` runs in, and a dependency of an extra
-is only followed when that extra is asked for.
+A dependency is only followed when its environment marker holds in the environment which ``pip-missing-reqs`` runs in, and a dependency of an extra is only followed when that extra is asked for.
 
 
 Using pyproject.toml instead of requirements.txt
@@ -201,8 +166,7 @@ For those, one way is to use an external tool to convert ``pyproject.toml`` to `
 
 Then you can use ``pip-missing-reqs`` and ``pip-extra-reqs`` as usual.
 
-Another way is to use a ``requirements.txt`` file within your ``pyproject.toml`` file,
-for example with the ``setuptools`` build backend:
+Another way is to use a ``requirements.txt`` file within your ``pyproject.toml`` file, for example with the ``setuptools`` build backend:
 
 .. code:: toml
 
@@ -224,35 +188,22 @@ Comparison with deptry
 ----------------------
 
 `deptry`_ is another tool which finds missing and unused dependencies.
-It overlaps with ``pip-check-reqs``, and differs in ways which may decide
-which one suits a project.
+It overlaps with ``pip-check-reqs``, and differs in ways which may decide which one suits a project.
 
-- ``deptry`` reads dependencies from ``pyproject.toml`` directly, whether
-  they follow PEP 621 or the Poetry or PDM format, as well as from
-  requirements files. ``pip-check-reqs`` reads requirements files only, so a
-  project which declares its dependencies in ``pyproject.toml`` must first
-  export them to a requirements file.
-- ``deptry`` runs more checks. As well as missing and unused dependencies,
-  it reports an import of a development dependency from non-development
-  code, an import of a standard library module which is listed as a
-  dependency, and an import of a transitive dependency which is not declared.
-  ``pip-check-reqs`` reports missing and extra requirements, and can check
-  that a file lists every transitive dependency with ``--transitive``.
-- ``deptry`` guesses the module name of a dependency which is not installed
-  by translating the distribution name, so it can run against an incomplete
-  environment at the cost of some accuracy. ``pip-check-reqs`` reads the
-  installed distribution only, and warns about each import or requirement it
-  cannot find.
-- ``deptry`` is configured in ``pyproject.toml`` and supports inline
-  ``# deptry: ignore`` comments. ``pip-check-reqs`` is configured on the
-  command line only.
+- ``deptry`` reads dependencies from ``pyproject.toml`` directly, whether they follow PEP 621 or the Poetry or PDM format, as well as from requirements files.
+  ``pip-check-reqs`` reads requirements files only, so a project which declares its dependencies in ``pyproject.toml`` must first export them to a requirements file.
+- ``deptry`` runs more checks.
+  As well as missing and unused dependencies, it reports an import of a development dependency from non-development code, an import of a standard library module which is listed as a dependency, and an import of a transitive dependency which is not declared.
+  ``pip-check-reqs`` reports missing and extra requirements, and can check that a file lists every transitive dependency with ``--transitive``.
+- ``deptry`` guesses the module name of a dependency which is not installed by translating the distribution name, so it can run against an incomplete environment at the cost of some accuracy.
+  ``pip-check-reqs`` reads the installed distribution only, and warns about each import or requirement it cannot find.
+- ``deptry`` is configured in ``pyproject.toml`` and supports inline ``# deptry: ignore`` comments.
+  ``pip-check-reqs`` is configured on the command line only.
 - ``deptry`` has a core written in Rust and is faster on a large codebase.
-  ``pip-check-reqs`` uses internals of ``pip`` which may change between
-  ``pip`` releases.
+  ``pip-check-reqs`` uses internals of ``pip`` which may change between ``pip`` releases.
 
-For a new project, ``deptry`` is likely the better choice. ``pip-check-reqs``
-remains a good fit for a project which manages its dependencies with
-requirements files, or which needs the ``--transitive`` check.
+For a new project, ``deptry`` is likely the better choice.
+``pip-check-reqs`` remains a good fit for a project which manages its dependencies with requirements files, or which needs the ``--transitive`` check.
 
 .. _`deptry`: https://github.com/fpgmaas/deptry
 


### PR DESCRIPTION
## Summary

- Reflow Markdown and reStructuredText prose so each sentence occupies one source line.
- Preserve tables, directives, code blocks, and vendored content.

## Validation
- Pinned Vale prose check
- Pandoc render-equivalence comparison
- git diff --check