### PR TITLE
Localize external type contracts

### DIFF
--- a/pip_check_reqs/common.py
+++ b/pip_check_reqs/common.py
@@ -19,10 +19,7 @@ from typing import TYPE_CHECKING
 from packaging.requirements import Requirement
 from packaging.utils import NormalizedName, canonicalize_name
 from pathspec import GitIgnoreSpec
-from pip._internal.commands.show import (
-    _PackageInfo,  # pyright: ignore[reportPrivateUsage]
-    search_packages_info,
-)
+from pip._internal.commands.show import search_packages_info
 from pip._internal.utils.urls import url_to_path
 
 from . import __version__
@@ -42,6 +39,15 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 
+@dataclass(frozen=True)
+class _InstalledPackage:
+    """The installed-package fields used from pip's show command."""
+
+    name: str
+    location: str
+    files: list[str] | None
+
+
 @cache
 def cached_resolve_path(path: Path) -> Path:
     return path.resolve()
@@ -52,12 +58,19 @@ def cached_resolve_path(path: Path) -> Path:
 # tests.
 # We cache the result to speed up tests.
 @cache
-def get_packages_info() -> list[_PackageInfo]:
+def get_packages_info() -> list[_InstalledPackage]:
     all_pkgs: list[str] = [
         dist.metadata["Name"] for dist in importlib.metadata.distributions()
     ]
 
-    return list(search_packages_info(query=all_pkgs, include_files=True))
+    return [
+        _InstalledPackage(
+            name=package.name,
+            location=package.location,
+            files=package.files,
+        )
+        for package in search_packages_info(query=all_pkgs, include_files=True)
+    ]
 
 
 @dataclass

--- a/tests/_monkeypatch.py
+++ b/tests/_monkeypatch.py
@@ -1,0 +1,15 @@
+"""Typed contracts for pytest helpers whose annotations are incomplete."""
+
+from typing import Protocol
+
+
+class _SyspathPrepender(Protocol):
+    """The part of ``pytest.MonkeyPatch`` used to prepend import paths."""
+
+    def syspath_prepend(self, path: str) -> None:
+        """Prepend a path and invalidate import caches."""
+
+
+def syspath_prepend(*, monkeypatch: _SyspathPrepender, path: str) -> None:
+    """Prepend a path through the locally typed pytest contract."""
+    monkeypatch.syspath_prepend(path)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from pip_check_reqs import common, requirements
+from tests._monkeypatch import syspath_prepend
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator
@@ -122,16 +123,8 @@ def editable_install(
         },
     )
 
-    # The parameter has no annotation until
-    # https://github.com/pytest-dev/pytest/pull/14988 is released.
-    monkeypatch.syspath_prepend(  # pyright: ignore[reportUnknownMemberType]
-        str(source_directory),
-    )
-    # The parameter has no annotation until
-    # https://github.com/pytest-dev/pytest/pull/14988 is released.
-    monkeypatch.syspath_prepend(  # pyright: ignore[reportUnknownMemberType]
-        str(site_packages),
-    )
+    syspath_prepend(monkeypatch=monkeypatch, path=str(source_directory))
+    syspath_prepend(monkeypatch=monkeypatch, path=str(site_packages))
 
     common.get_packages_info.cache_clear()
     common.editable_source_directories.cache_clear()
@@ -188,11 +181,7 @@ def nested_install(
         record_file.write(f"{module_file.name},,\n")
 
     monkeypatch.chdir(tmp_path)
-    # The parameter has no annotation until
-    # https://github.com/pytest-dev/pytest/pull/14988 is released.
-    monkeypatch.syspath_prepend(  # pyright: ignore[reportUnknownMemberType]
-        str(site_packages),
-    )
+    syspath_prepend(monkeypatch=monkeypatch, path=str(site_packages))
     common.get_packages_info.cache_clear()
 
     yield NestedInstall(
@@ -273,11 +262,7 @@ def dependency_chain(
     with record.open("a", encoding="utf-8") as record_file:
         record_file.write(f"{chain.top_module}/__init__.py,,\n")
 
-    # The parameter has no annotation until
-    # https://github.com/pytest-dev/pytest/pull/14988 is released.
-    monkeypatch.syspath_prepend(  # pyright: ignore[reportUnknownMemberType]
-        str(site_packages),
-    )
+    syspath_prepend(monkeypatch=monkeypatch, path=str(site_packages))
     common.get_packages_info.cache_clear()
 
     yield chain

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -17,6 +17,7 @@ from packaging.utils import canonicalize_name
 
 import __main__
 from pip_check_reqs import __version__, common
+from tests._monkeypatch import syspath_prepend
 
 from .conftest import write_dist_info
 
@@ -1172,11 +1173,7 @@ def test_used_packages_other_case_path(  # pragma: no cover
     source_file = tmp_path / "source.py"
     source_file.write_text(f"import {module_name}\n", encoding="utf-8")
 
-    # The parameter has no annotation until
-    # https://github.com/pytest-dev/pytest/pull/14988 is released.
-    monkeypatch.syspath_prepend(  # pyright: ignore[reportUnknownMemberType]
-        str(other_spelling),
-    )
+    syspath_prepend(monkeypatch=monkeypatch, path=str(other_spelling))
     common.get_packages_info.cache_clear()
     try:
         imported = common.find_imported_modules(
@@ -1232,11 +1229,7 @@ def test_editable_source_directories(
         direct_url=None,
     )
 
-    # The parameter has no annotation until
-    # https://github.com/pytest-dev/pytest/pull/14988 is released.
-    monkeypatch.syspath_prepend(  # pyright: ignore[reportUnknownMemberType]
-        str(site_packages),
-    )
+    syspath_prepend(monkeypatch=monkeypatch, path=str(site_packages))
     common.editable_source_directories.cache_clear()
 
     try:

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -9,6 +9,7 @@ import pytest
 from packaging.requirements import Requirement
 
 from pip_check_reqs import common, requirements
+from tests._monkeypatch import syspath_prepend
 
 from .conftest import write_dist_info
 
@@ -337,11 +338,7 @@ def test_requirements_file_specs_installed_url_requirement(
         distribution_name=distribution_name,
         direct_url=direct_url,
     )
-    # The parameter has no annotation until
-    # https://github.com/pytest-dev/pytest/pull/14988 is released.
-    monkeypatch.syspath_prepend(  # pyright: ignore[reportUnknownMemberType]
-        str(site_packages),
-    )
+    syspath_prepend(monkeypatch=monkeypatch, path=str(site_packages))
     requirements.direct_url_distribution_names.cache_clear()
 
     fake_requirements_file = tmp_path / "requirements.txt"


### PR DESCRIPTION
The code depended directly on pip's private `_PackageInfo` type, while tests repeatedly suppressed Pyright diagnostics caused by pytest's unannotated `syspath_prepend` parameter.

This copies the three pip result fields the project actually consumes into a local immutable record, insulating the rest of the code from the private type. A small test-only Protocol documents pytest's missing parameter contract and removes all seven Pyright suppressions.

Validation:

- `uv run --extra dev pytest -q` (178 passed, 1 skipped)
- pre-commit hook stage passed
- pre-push hook stage passed (Mypy and Pyright)
