### PR TITLE
Ban operator.attrgetter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,7 @@ lint.ignore = [
 lint.unfixable = [
   "ERA001",
 ]
+lint.flake8-tidy-imports.banned-api."operator.attrgetter".msg = "operator.attrgetter is banned: use a lambda instead."
 
 [tool.pylint]
 "DEPRECATED BUILTINS".bad-functions = [


### PR DESCRIPTION
## Summary

- ban `operator.attrgetter` through Ruff's banned API configuration
- direct callers to use an explicit lambda

## Validation

- `pyproject-fmt --check pyproject.toml`
- `ruff check .`