### PR TITLE
Use typed ignore callbacks for empty configurations

### DIFF
--- a/pip_check_reqs/common.py
+++ b/pip_check_reqs/common.py
@@ -833,17 +833,11 @@ def _normalized(*, path: Path) -> Path:
     return normalized
 
 
-def _null_ignorer(_: object) -> bool:
-    return False
-
-
 def ignorer(*, ignore_cfg: list[str]) -> Callable[[str], bool]:
     """Return a function which tells whether a name matches an ignore glob.
 
     The name is a module or distribution name.
     """
-    if not ignore_cfg:
-        return _null_ignorer
 
     def ignorer_function(candidate: str) -> bool:
         return any(fnmatch.fnmatch(candidate, ignore) for ignore in ignore_cfg)
@@ -857,8 +851,6 @@ def file_ignorer(*, ignore_cfg: list[str]) -> Callable[[Path], bool]:
     A glob is matched against the path as given, and against the path
     relative to the working directory.
     """
-    if not ignore_cfg:
-        return _null_ignorer
 
     def ignorer_function(candidate_path: Path) -> bool:
         working_directory = Path.cwd()


### PR DESCRIPTION
Remove the generic `_null_ignorer(_: object)` callback. The ordinary string and path callbacks already return `False` when their pattern list is empty, so using them for every configuration preserves behavior while keeping each callback’s actual argument type.

Local verification:
- all repository hook stages
- `uv run --extra dev pytest` (178 passed, 1 skipped)