### PR TITLE
Validate direct URL metadata types

### DIFF
--- a/pip_check_reqs/common.py
+++ b/pip_check_reqs/common.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass, field
 from functools import cache
 from importlib.util import find_spec
 from pathlib import Path
-from typing import TYPE_CHECKING, NotRequired, TypedDict, TypeGuard
+from typing import TYPE_CHECKING, TypedDict, TypeGuard
 
 from packaging.requirements import Requirement
 from packaging.utils import NormalizedName, canonicalize_name
@@ -48,10 +48,10 @@ class _InstalledPackage:
     files: list[str] | None
 
 
-class _DirectoryInfo(TypedDict):
+class _DirectoryInfo(TypedDict, total=False):
     """PEP 610 directory-install fields used by this module."""
 
-    editable: NotRequired[bool]
+    editable: bool
 
 
 class _VCSInfo(TypedDict):
@@ -60,13 +60,18 @@ class _VCSInfo(TypedDict):
     vcs: str
 
 
-class _DirectURL(TypedDict):
+class _DirectURLOptional(TypedDict, total=False):
+    """Optional PEP 610 direct-URL fields used by this module."""
+
+    dir_info: _DirectoryInfo
+    vcs_info: _VCSInfo
+    subdirectory: str
+
+
+class _DirectURL(_DirectURLOptional):
     """PEP 610 direct-URL fields used by this module."""
 
     url: str
-    dir_info: NotRequired[_DirectoryInfo]
-    vcs_info: NotRequired[_VCSInfo]
-    subdirectory: NotRequired[str]
 
 
 def _is_string_object_dict(

--- a/pip_check_reqs/common.py
+++ b/pip_check_reqs/common.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass, field
 from functools import cache
 from importlib.util import find_spec
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, NotRequired, TypedDict, TypeGuard
 
 from packaging.requirements import Requirement
 from packaging.utils import NormalizedName, canonicalize_name
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
         Iterator,
         Sequence,
     )
-    from typing import Any, NoReturn, TextIO
+    from typing import NoReturn, TextIO
 
 
 log = logging.getLogger(__name__)
@@ -46,6 +46,60 @@ class _InstalledPackage:
     name: str
     location: str
     files: list[str] | None
+
+
+class _DirectoryInfo(TypedDict):
+    """PEP 610 directory-install fields used by this module."""
+
+    editable: NotRequired[bool]
+
+
+class _VCSInfo(TypedDict):
+    """PEP 610 version-control fields used by this project."""
+
+    vcs: str
+
+
+class _DirectURL(TypedDict):
+    """PEP 610 direct-URL fields used by this module."""
+
+    url: str
+    dir_info: NotRequired[_DirectoryInfo]
+    vcs_info: NotRequired[_VCSInfo]
+    subdirectory: NotRequired[str]
+
+
+def _is_string_object_dict(
+    value: object,
+    /,
+) -> TypeGuard[dict[str, object]]:
+    """Return whether a decoded JSON value is an object."""
+    # JSON object keys are strings by definition.
+    return isinstance(value, dict)
+
+
+def _is_direct_url(value: object, /) -> TypeGuard[_DirectURL]:
+    """Return whether decoded data has the PEP 610 fields we consume."""
+    if not _is_string_object_dict(value) or not isinstance(
+        value.get("url"),
+        str,
+    ):
+        return False
+    directory_info = value.get("dir_info")
+    if directory_info is not None:
+        if not _is_string_object_dict(directory_info):
+            return False
+        editable = directory_info.get("editable")
+        if editable is not None and not isinstance(editable, bool):
+            return False
+    vcs_info = value.get("vcs_info")
+    if vcs_info is not None and (
+        not _is_string_object_dict(vcs_info)
+        or not isinstance(vcs_info.get("vcs"), str)
+    ):
+        return False
+    subdirectory = value.get("subdirectory")
+    return subdirectory is None or isinstance(subdirectory, str)
 
 
 @cache
@@ -627,7 +681,7 @@ def _installed_files() -> dict[Path, str]:
     return installed_files
 
 
-def direct_urls() -> Iterator[tuple[str, dict[str, Any]]]:
+def direct_urls() -> Iterator[tuple[str, _DirectURL]]:
     """Yield the name and direct URL of each distribution installed from one.
 
     A distribution installed from a URL, a local directory or a version
@@ -640,7 +694,10 @@ def direct_urls() -> Iterator[tuple[str, dict[str, Any]]]:
             continue
 
         name: str = distribution.metadata["Name"]
-        direct_url: dict[str, Any] = json.loads(direct_url_text)
+        direct_url: object = json.loads(direct_url_text)
+        if not _is_direct_url(direct_url):
+            message = f"Invalid direct_url.json for distribution {name!r}"
+            raise ValueError(message)
         yield name, direct_url
 
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1252,3 +1252,42 @@ def test_editable_source_directories(
     assert written_directories == {
         editable_source_directory.resolve(): "editable-package-12345",
     }
+
+
+@pytest.mark.parametrize(
+    "direct_url",
+    [
+        {"url": 1},
+        {"url": "file:///tmp/project", "dir_info": []},
+        {
+            "url": "file:///tmp/project",
+            "dir_info": {"editable": "yes"},
+        },
+        {"url": "https://example.com/project", "vcs_info": []},
+        {
+            "url": "https://example.com/project",
+            "vcs_info": {"vcs": 1},
+        },
+        {"url": "https://example.com/project", "subdirectory": 1},
+    ],
+)
+def test_direct_urls_rejects_invalid_pep_610_data(
+    *,
+    direct_url: dict[str, object],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Malformed direct URL metadata is rejected at the file boundary."""
+    site_packages = tmp_path / "site-packages"
+    write_dist_info(
+        site_packages=site_packages,
+        distribution_name="invalid-direct-url-package-12345",
+        direct_url=direct_url,
+    )
+    syspath_prepend(monkeypatch=monkeypatch, path=str(site_packages))
+
+    with pytest.raises(
+        expected_exception=ValueError,
+        match=r"Invalid direct_url\.json",
+    ):
+        list(common.direct_urls())


### PR DESCRIPTION
## Summary

- model the consumed PEP 610 direct URL fields with focused `TypedDict` definitions
- validate decoded metadata at the file boundary
- remove the broad `Any` return type and cover malformed records through `direct_urls()`

## Validation

- `prek run --all-files`
- `prek run --all-files --hook-stage pre-push`
- `uv run --python 3.10 --resolution=highest --extra dev pytest -q --cov-fail-under 100 --cov=pip_check_reqs/ --cov=tests tests/` (184 passed, 1 skipped, 100% coverage)
